### PR TITLE
docs: fix markdown parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
     <a href="https://circleci.com/gh/nrwl/angular-console/tree/master"><img
 		alt="Build Status"
 		src="https://circleci.com/gh/nrwl/angular-console/tree/master.svg?style=svg"></a>
-		
     <a href="https://opensource.org/licenses/MIT"><img
 		alt="License"
 		src="https://img.shields.io/npm/l/@nrwl/schematics.svg"></a>


### PR DESCRIPTION
Current behavior

![image](https://user-images.githubusercontent.com/12021443/43969823-1275a1da-9cd4-11e8-8482-8c1e50f7f77b.png)

Expected behavior 

![image](https://user-images.githubusercontent.com/12021443/43969849-25045102-9cd4-11e8-9496-7e44fd2491ac.png)
