### PR TITLE
style:Task Output label in task-runner component is off-centre

### DIFF
--- a/libs/ui/src/lib/task-runner/task-runner.component.scss
+++ b/libs/ui/src/lib/task-runner/task-runner.component.scss
@@ -42,6 +42,6 @@
   .window-header {
     color: white;
     font-size: 14px;
-    padding: 0 64px;
+    padding: 0 64px 0 98px;
   }
 }


### PR DESCRIPTION
A minor css fix in the task-runner component (#80 )