### PR TITLE
feat: syncs up breadcrumbs to document title

### DIFF
--- a/apps/angular-console-e2e/src/integration/workspaces.spec.ts
+++ b/apps/angular-console-e2e/src/integration/workspaces.spec.ts
@@ -41,6 +41,8 @@ describe('Workspaces', () => {
     waitForNgNew();
 
     cy.get('div.title').contains('Projects');
+
+    cy.get('div.title').contains(name);
   });
 
   it('imports a workspace', () => {

--- a/apps/angular-console/src/index.html
+++ b/apps/angular-console/src/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Angular Console</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
The angular-console app will now update title accordingly. (closes #102)

## Changes

- Title is now the breadcrumbs in reverse hierarchical order, with `Angular Console` appended at the end.
- The app component is responsible for syncing between breadcrumbs and document title.

## Screenshot

![screen shot 2018-10-02 at 3 28 44 pm](https://user-images.githubusercontent.com/53559/46371999-e1599900-c657-11e8-87d2-735c9f8d02a1.png)
