### PR TITLE
fix: guard against schematics that do not have schema defined

### DIFF
--- a/server/src/api/read-schematic-collections.ts
+++ b/server/src/api/read-schematic-collections.ts
@@ -68,7 +68,7 @@ function readSchematicCollections(
     schematics: [] as Schematic[]
   };
   Object.entries(collection.json.schematics).forEach(([k, v]: [any, any]) => {
-    if (!v.hidden && !v.extends) {
+    if (canAdd(v)) {
       const schematicSchema = readJsonFile(
         v.schema,
         path.dirname(collection.path)
@@ -83,4 +83,8 @@ function readSchematicCollections(
     }
   });
   return schematicCollection;
+}
+
+function canAdd(s: any) : boolean {
+  return !s.hidden && !s.extends && s.schema
 }


### PR DESCRIPTION
The schema entry for defining options may not be present, so it's best to skip over these entries.

This fixes the issue where Generate Code breaks after `@angular/elements` schematics are installed. Not sure if there is a way we can still display schematics from elements without having the schema.