### PR TITLE
fix: add validation when creating new workspace with conflicting name

### DIFF
--- a/libs/feature-workspaces/src/lib/new-workspace/new-workspace.component.html
+++ b/libs/feature-workspaces/src/lib/new-workspace/new-workspace.component.html
@@ -25,6 +25,9 @@
         <mat-form-field class="workspace-name-form-field" fxFlex>
           <mat-label>Workspace Name</mat-label>
           <input matInput placeholder="MyNewWorkspace" required formControlName="name" name="name">
+          <mat-error *ngIf="form.get('name').invalid && form.get('name').errors.nameTaken">
+            This name is already taken
+          </mat-error>
         </mat-form-field>
       </mat-expansion-panel>
 

--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -15,6 +15,7 @@ export interface LocalFile {
 
 export interface Directory {
   path: string;
+  exists: boolean;
   files: Array<LocalFile>;
 }
 

--- a/libs/utils/src/lib/finder.service.ts
+++ b/libs/utils/src/lib/finder.service.ts
@@ -22,6 +22,7 @@ export class Finder {
           query($path: String!, $onlyDirectories: Boolean) {
             directory(path: $path, onlyDirectories: $onlyDirectories) {
               path
+              exists
               files {
                 name
                 type

--- a/server/src/graphql-types.ts
+++ b/server/src/graphql-types.ts
@@ -161,6 +161,7 @@ export interface CommandResult {
 
 export interface FilesType {
   path: string;
+  exists: boolean;
   files?: (FileListType | null)[] | null;
 }
 
@@ -958,6 +959,7 @@ export namespace CommandResultResolvers {
 export namespace FilesTypeResolvers {
   export interface Resolvers<Context = any> {
     path?: PathResolver<string, any, Context>;
+    exists?: ExistsResolver<boolean, any, Context>;
     files?: FilesResolver<(FileListType | null)[] | null, any, Context>;
   }
 
@@ -966,6 +968,11 @@ export namespace FilesTypeResolvers {
     Parent,
     Context
   >;
+  export type ExistsResolver<
+    R = boolean,
+    Parent = any,
+    Context = any
+  > = Resolver<R, Parent, Context>;
   export type FilesResolver<
     R = (FileListType | null)[] | null,
     Parent = any,

--- a/server/src/schema/resolvers.ts
+++ b/server/src/schema/resolvers.ts
@@ -190,7 +190,7 @@ const Database: DatabaseResolvers.Resolvers = {
         args.showHidden
       ).toPromise();
       if (!v) {
-        return { path: args.path, files: [] };
+        return { path: args.path, exists: false, files: [] };
       }
       return v;
     } catch (e) {

--- a/server/src/schema/type-defs.ts
+++ b/server/src/schema/type-defs.ts
@@ -89,6 +89,7 @@ export const typeDefs = gql`
 
   type FilesType {
     path: String!
+    exists: Boolean!
     files: [FileListType]
   }
 


### PR DESCRIPTION
Closes #234

## Changes

- Querying for a directory no longer errors out when it is not found, instead it will return with `exists: false`.
- Add async validation for path + name during workspace creation.