### PR TITLE
chore: updates server test so jest can run interactively in non-CI environment

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -57,7 +57,7 @@ module.exports = {
         write: 'prettier --write \"./server/**/*.ts\"',
         check: 'prettier --list-different \"./server/**/*.ts\"'
       },
-      test: 'jest --maxWorkers=1 ./dist/server/test',
+      test: 'node ./tools/scripts/test ./dist/server/test',
       'gen-graphql-types': 'ts-node tools/gen-graphql-types.ts'
     },
     mac: {

--- a/tools/scripts/test.js
+++ b/tools/scripts/test.js
@@ -1,0 +1,13 @@
+process.env.NODE_ENV = 'test';
+
+const jest = require('jest');
+
+const argv = process.argv.slice(2);
+
+if (process.env.CI) {
+  argv.push('--maxWorkers=1')
+} else {
+  argv.push('--watch')
+}
+
+jest.run(argv);


### PR DESCRIPTION
Running `yarn start server.test` locally will run jest interactively with CPU count as max workers (default).