### PR TITLE
fix: disable the browser's autocomplete when creating a new workspace

### DIFF
--- a/libs/feature-workspaces/src/lib/new-workspace/new-workspace.component.html
+++ b/libs/feature-workspaces/src/lib/new-workspace/new-workspace.component.html
@@ -24,7 +24,7 @@
 
         <mat-form-field class="workspace-name-form-field" fxFlex>
           <mat-label>Workspace Name</mat-label>
-          <input matInput placeholder="MyNewWorkspace" required formControlName="name" name="name">
+          <input matInput placeholder="MyNewWorkspace" required formControlName="name" name="name" autocomplete="off"/>
         </mat-form-field>
       </mat-expansion-panel>
 


### PR DESCRIPTION
remove the undesired behavior of the browser's autocomplete when creating a new workspace.