### PR TITLE
docs: add script to run electron app on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ After that, run `yarn start dev.prepare`. Every time you add or remove dependenc
 
 After this, run `yarn start dev.up` to start the dev environment. The application will start the process listening on port 4200. 
 
-You can also run the electron app by running `yarn start mac.start-electron` or `yarn start win.start-electron`.
+You can also run the electron app by running `yarn start mac.start-electron`, `yarn start win.start-electron` or `yarn start linux.start-electron`.
 
 
 ## Running Unit Tests


### PR DESCRIPTION
It was missing from the CONTRIBUTING and people could think it was not possible