### PR TITLE
fix: use the workspace basename as a fallback name...

### DIFF
--- a/libs/feature-workspaces/src/lib/workspaces/workspaces.component.ts
+++ b/libs/feature-workspaces/src/lib/workspaces/workspaces.component.ts
@@ -15,7 +15,7 @@ import { MatDialog } from '@angular/material';
 import { ContextualActionBarService } from '@nrwl/angular-console-enterprise-frontend';
 import { NewWorkspaceComponent } from '../new-workspace/new-workspace.component';
 import { WorkspacesService } from '../workspaces.service';
-import { startWith, shareReplay } from 'rxjs/operators';
+import { shareReplay } from 'rxjs/operators';
 
 @Component({
   selector: 'angular-console-workspaces',

--- a/server/src/schema/resolvers.ts
+++ b/server/src/schema/resolvers.ts
@@ -178,7 +178,7 @@ const Database: DatabaseResolvers.Resolvers = {
       context.angularJson = angularJson;
 
       return {
-        name: packageJson.name,
+        name: packageJson.name || path.basename(args.path),
         path: args.path,
         dependencies: readDependencies(packageJson),
         extensions: readExtensions(packageJson),


### PR DESCRIPTION
when package.json is null or empty.

Closes #177