### PR TITLE
fix: make graphql gen script platform specific

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -39,7 +39,7 @@ module.exports = {
       test: 'nx affected:test --base=master'
     },
     server: {
-      compile: npsUtils.series.nps('server.gen-graphql-types', 'server.gen-apollo-angular', 'server.compile-only', 'server.move-graphql'),
+      compile: npsUtils.series.nps('server.gen-graphql-types', 'server.gen-apollo-angular', 'server.compile-only', withPlatform('move-graphql')),
       'compile-only': 'tsc -p server/tsconfig.json',
       format: {
         default: npsUtils.series.nps('server.format.write'),
@@ -47,7 +47,6 @@ module.exports = {
         check: 'prettier --list-different \"./server/**/*.ts\"'
       },
       test: 'node ./tools/scripts/test ./server/test',
-      'move-graphql': 'cp server/src/schema/schema.graphql dist/server/src/schema/schema.graphql',
       'gen-graphql-types': 'gql-gen --config codegen-server.yml',
       'gen-apollo-angular': 'gql-gen --config codegen-client.js'
     },
@@ -61,6 +60,7 @@ module.exports = {
       'start-server': 'electron dist/server --server --inspect=9229',
       'start-electron': 'NODE_ENV=development electron dist/server',
       'builder-dist': 'electron-builder --mac -p never',
+      'move-graphql': 'cp server/src/schema/schema.graphql dist/server/src/schema/schema.graphql'
     },
     linux: {
       'clean': 'rm -rf dist',
@@ -71,7 +71,8 @@ module.exports = {
       'copy-to-osbuilds': 'cp -r dist/packages osbuilds/linux',
       'start-server': 'electron dist/server --server --inspect=9229',
       'start-electron': 'NODE_ENV=development electron dist/server',
-      'builder-dist': 'electron-builder --linux -p never'
+      'builder-dist': 'electron-builder --linux -p never',
+      'move-graphql': 'cp server/src/schema/schema.graphql dist/server/src/schema/schema.graphql'
     },
     win: {
       'clean': 'if exist dist rmdir dist /s /q',
@@ -82,7 +83,8 @@ module.exports = {
       'copy-to-osbuilds': 'robocopy dist\\packages osbuilds\\win /e || echo 0',
       'start-server': 'electron dist\\server --server --inspect=9229',
       'start-electron': 'electron dist\\server',
-      'builder-dist': 'electron-builder --win -p never'
+      'builder-dist': 'electron-builder --win -p never',
+      'move-graphql': 'copy server\\src\\schema\\schema.graphql dist\\server\\src\\schema\\schema.graphql'
     },
     dev: {
       'patch-cli': 'node ./tools/scripts/patch-cli.js',


### PR DESCRIPTION
Use 'withPlatform' in server.compile to gen Graphql with platform specific commands (copy vs cp)
#418 

