### PR TITLE
fix: add new schematic collections for autocomplete and important fields

### DIFF
--- a/libs/utils/src/lib/serializer.service.spec.ts
+++ b/libs/utils/src/lib/serializer.service.spec.ts
@@ -30,6 +30,7 @@ describe('Serializer', () => {
   });
 
   describe('normalizeSchematic', () => {
+    serializer = new Serializer();
     const schematic: Schematic = {
       collection: '@nrwl/testing',
       name: 'normalized',
@@ -67,9 +68,8 @@ describe('Serializer', () => {
         }
       ]
     };
-    let normalized: Schematic;
+    const normalized: Schematic = serializer.normalizeSchematic(schematic);
     it('should normalize the schematic, removing periods from the end of description', () => {
-      normalized = serializer.normalizeSchematic(schematic);
       expect(normalized.description.lastIndexOf('.')).toBeLessThan(
         normalized.description.length
       );
@@ -84,6 +84,12 @@ describe('Serializer', () => {
           case 'ignoreImportant':
             expect(field.important).toEqual(false);
             break;
+          default:
+            throw new Error(
+              `Unexpected field name '${
+                field.name
+              }' in normalizeSchematic test cases`
+            );
         }
       });
     });

--- a/libs/utils/src/lib/serializer.service.spec.ts
+++ b/libs/utils/src/lib/serializer.service.spec.ts
@@ -1,3 +1,4 @@
+import { Schematic, Field } from '@angular-console/schema';
 import { Serializer } from './serializer.service';
 
 describe('Serializer', () => {
@@ -25,6 +26,66 @@ describe('Serializer', () => {
         ]
       );
       expect(serialized).toEqual(['--', '--one=two']);
+    });
+  });
+
+  describe('normalizeSchematic', () => {
+    const schematic: Schematic = {
+      collection: '@nrwl/testing',
+      name: 'normalized',
+      description: 'a schematic to be normalized.',
+      schema: [
+        {
+          type: 'arguments',
+          name: 'required',
+          enum: [],
+          description: '',
+          defaultValue: null,
+          required: true,
+          positional: false,
+          important: false
+        },
+        {
+          type: 'arguments',
+          name: 'positional',
+          enum: [],
+          description: '',
+          defaultValue: null,
+          required: false,
+          positional: true,
+          important: false
+        },
+        {
+          type: 'arguments',
+          name: 'ignoreImportant',
+          enum: [],
+          description: '',
+          defaultValue: null,
+          required: false,
+          positional: false,
+          important: true
+        }
+      ]
+    };
+    let normalized: Schematic;
+    it('should normalize the schematic, removing periods from the end of description', () => {
+      normalized = serializer.normalizeSchematic(schematic);
+      expect(normalized.description.lastIndexOf('.')).toBeLessThan(
+        normalized.description.length
+      );
+    });
+    it('should recognize positional and required fields as important but ignore previous values of important', () => {
+      normalized.schema.forEach((field: Field) => {
+        switch (field.name) {
+          case 'required':
+          case 'positional':
+            expect(field.important).toEqual(true);
+            break;
+          case 'ignoreImportant':
+            expect(field.important).toEqual(false);
+            break;
+        }
+      });
     });
   });
 });

--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -10,12 +10,13 @@ export class Serializer {
       ...f,
       important:
         f.positional ||
+        f.required ||
         this.importantSchematicField(schematic.collection, f.name),
       completion: this.completionSchematicType(schematic.collection, f.name)
     }));
     const normal = {
       ...schematic,
-      schema: this.reoderFields(schema)
+      schema: this.reorderFields(schema)
     };
     if (normal.description.endsWith('.')) {
       normal.description = normal.description.slice(
@@ -27,7 +28,7 @@ export class Serializer {
   }
 
   normalizeTarget(builder: string, schema: Field[]): Field[] {
-    return this.reoderFields(
+    return this.reorderFields(
       schema.map(f => ({
         ...f,
         required: false,
@@ -37,7 +38,7 @@ export class Serializer {
     );
   }
 
-  reoderFields(fields: Field[]): Field[] {
+  reorderFields(fields: Field[]): Field[] {
     return [
       ...fields.filter(r => r.positional),
       ...fields.filter(r => !r.positional && r.important),
@@ -114,15 +115,19 @@ export class Serializer {
   }
 
   private completionSchematicType(collection: string, name: string): any {
-    if (collection === '@nrwl/schematics' && name === 'module') {
-      return 'absoluteModules';
-    }
-    if (
-      collection === '@schematics/angular' ||
-      collection === '@ngrx/schematics'
-    ) {
-      if (name === 'project') return 'projects';
-      if (name === 'module') return 'localModules';
+    switch (collection) {
+      case '@nrwl/schematics':
+        if (name === 'module' || name === 'parentModule') {
+          return 'absoluteModules';
+        }
+        break;
+      case '@schematics/angular':
+      case '@angular/material':
+      case '@angular/cdk':
+      case '@ngrx/schematics':
+        if (name === 'project') return 'projects';
+        if (name === 'module') return 'localModules';
+        break;
     }
     return undefined;
   }


### PR DESCRIPTION
Add 'required' check for determining important schematic fields
Add 'parentModule' for '@nrwl/schematics' auto completions
Add '@angular/cdk', '@angular/material' to standard completion handling
Fixes a typo in methodname reoderFields => reorderFields

#304 

