### PR TITLE
fix: Navigate back to previous location when active target or schematic is not present.

### DIFF
--- a/apps/angular-console-e2e/src/integration/projects.spec.ts
+++ b/apps/angular-console-e2e/src/integration/projects.spec.ts
@@ -31,4 +31,15 @@ describe('Projects', () => {
       expect($p[0].value).to.equal('proj');
     });
   });
+
+  it('provides navigation to and from command runners', () => {
+    cy.contains('Generate Component').click();
+    cy.get('.exit-action').click();
+
+    projectNames($p => {
+      expect($p.length).to.equal(2);
+      expect(texts($p)[0]).to.contain('proj');
+      expect(texts($p)[1]).to.contain('proj-e2e');
+    });
+  });
 });

--- a/apps/angular-console/src/app/app.component.ts
+++ b/apps/angular-console/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { FADE_IN } from '@angular-console/ui';
-import { Settings } from '@angular-console/utils';
+import { RouterNavigationService, Settings } from '@angular-console/utils';
 import { transition, trigger } from '@angular/animations';
 import {
   Component,
@@ -9,7 +9,7 @@ import {
   ChangeDetectionStrategy
 } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { RouterOutlet, Router } from '@angular/router';
+import { RouterOutlet } from '@angular/router';
 import {
   Breadcrumb,
   ContextualActionBarService
@@ -17,13 +17,6 @@ import {
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-interface SidenavLink {
-  icon: string;
-  route: string;
-  text: string;
-}
-
-const DEFAULT_TITLE = 'Angular Console';
 const TITLE_SEPARATOR = ' | ';
 
 @Component({
@@ -41,8 +34,6 @@ const TITLE_SEPARATOR = ' | ';
 export class AppComponent implements OnInit, OnDestroy {
   @ViewChild(RouterOutlet) routerOutlet: RouterOutlet;
   routerTransition: Observable<string>;
-  settingsLoaded: boolean;
-  showSiteMenu = false;
 
   ngOnInit() {
     this.contextualActionBarService.contextualTabs$.next(null);
@@ -58,7 +49,9 @@ export class AppComponent implements OnInit, OnDestroy {
   constructor(
     settings: Settings,
     private readonly contextualActionBarService: ContextualActionBarService,
-    private readonly titleService: Title
+    private readonly titleService: Title,
+    // Ensures we allow location ext to listen on all router events no matter which route user enters into first.
+    private readonly routerNavService: RouterNavigationService
   ) {
     settings.fetch().subscribe();
   }

--- a/libs/feature-extensions/src/lib/extensions/extensions.component.ts
+++ b/libs/feature-extensions/src/lib/extensions/extensions.component.ts
@@ -11,7 +11,10 @@ import {
   switchMap
 } from 'rxjs/operators';
 import { TaskCollection, TaskCollections, Task } from '@angular-console/ui';
-import { EXTENSIONS_POLLING } from '@angular-console/utils';
+import {
+  EXTENSIONS_POLLING,
+  RouterNavigationService
+} from '@angular-console/utils';
 import { WorkspaceAndExtensionsGQL } from '../generated/graphql';
 
 interface ExtensionId {
@@ -101,7 +104,8 @@ export class ExtensionsComponent {
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
-    private readonly workspaceAndExtensionsGQL: WorkspaceAndExtensionsGQL
+    private readonly workspaceAndExtensionsGQL: WorkspaceAndExtensionsGQL,
+    private readonly locationExt: RouterNavigationService
   ) {}
 
   navigateToSelectedExtension(s: Extension | null) {
@@ -110,7 +114,9 @@ export class ExtensionsComponent {
         relativeTo: this.route
       });
     } else {
-      this.router.navigate(['.'], { relativeTo: this.route });
+      this.locationExt.goBackOrNavigateToFallback(['.'], {
+        relativeTo: this.route
+      });
     }
   }
 

--- a/libs/feature-generate/src/lib/schematics/schematics.component.ts
+++ b/libs/feature-generate/src/lib/schematics/schematics.component.ts
@@ -12,8 +12,12 @@ import {
   switchMap,
   tap
 } from 'rxjs/operators';
-import { SCHEMATICS_POLLING } from '@angular-console/utils';
+import {
+  RouterNavigationService,
+  SCHEMATICS_POLLING
+} from '@angular-console/utils';
 import { SchematicCollectionsGQL } from '../generated/graphql';
+import { Location } from '@angular/common';
 
 interface SchematicId {
   collectionName: string | undefined;
@@ -103,7 +107,8 @@ export class SchematicsComponent {
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
-    private readonly schematicCollectionsGQL: SchematicCollectionsGQL
+    private readonly schematicCollectionsGQL: SchematicCollectionsGQL,
+    private readonly locationExt: RouterNavigationService
   ) {}
 
   navigateToSelectedSchematic(s: Schematic | null) {
@@ -113,7 +118,9 @@ export class SchematicsComponent {
         { relativeTo: this.route }
       );
     } else {
-      this.router.navigate(['.'], { relativeTo: this.route });
+      this.locationExt.goBackOrNavigateToFallback(['.'], {
+        relativeTo: this.route
+      });
     }
   }
 

--- a/libs/feature-run/src/lib/targets/targets.component.ts
+++ b/libs/feature-run/src/lib/targets/targets.component.ts
@@ -10,8 +10,12 @@ import {
   startWith,
   distinctUntilChanged
 } from 'rxjs/operators';
-import { TARGET_POLLING } from '@angular-console/utils';
+import {
+  RouterNavigationService,
+  TARGET_POLLING
+} from '@angular-console/utils';
 import { WorkspaceAndProjectsGQL } from '../generated/graphql';
+import { Location } from '@angular/common';
 
 interface Target {
   projectName: string;
@@ -134,7 +138,8 @@ export class TargetsComponent {
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
-    private readonly workspaceAndProjectsGQL: WorkspaceAndProjectsGQL
+    private readonly workspaceAndProjectsGQL: WorkspaceAndProjectsGQL,
+    private readonly locationExt: RouterNavigationService
   ) {}
 
   navigateToSelectedTarget(target: Target | null) {
@@ -151,7 +156,9 @@ export class TargetsComponent {
         { relativeTo: this.route }
       );
     } else {
-      this.router.navigate(['.'], { relativeTo: this.route });
+      this.locationExt.goBackOrNavigateToFallback(['.'], {
+        relativeTo: this.route
+      });
     }
   }
 

--- a/libs/ui/src/lib/task-selector/task-selector.component.ts
+++ b/libs/ui/src/lib/task-selector/task-selector.component.ts
@@ -69,9 +69,7 @@ export class TaskSelectorComponent<T> implements OnInit, OnDestroy {
     actions => {
       if (actions === null) {
         this.taskAnimationState$.next('expand');
-        setTimeout(() => {
-          this.selectionChange.next(null);
-        }, ANIMATION_MILLIS);
+        this.selectionChange.next(null);
       }
     }
   );
@@ -128,8 +126,8 @@ export class TaskSelectorComponent<T> implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.selectTask(null);
     this.contextActionCloseSubscription.unsubscribe();
+    this.selectTask(null);
   }
 
   trackByCollectionName(_: number, taskCollection: TaskCollection<T>) {

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -8,5 +8,6 @@ export * from './lib/open-in-browser.service';
 export * from './lib/polling-constants';
 export * from './lib/serializer.service';
 export * from './lib/settings.service';
+export * from './lib/router-navigation.service';
 export * from './lib/show-item-in-folder.service';
 export { OpenDocGQL } from './lib/generated/graphql';

--- a/libs/utils/src/lib/router-navigation.service.spec.ts
+++ b/libs/utils/src/lib/router-navigation.service.spec.ts
@@ -1,0 +1,67 @@
+import { fakeAsync, getTestBed, TestBed } from '@angular/core/testing';
+import { RouterNavigationService } from './router-navigation.service';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+import { Component, NgModule } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NavigationEnd, Router, Routes } from '@angular/router';
+import { filter } from 'rxjs/operators';
+
+@Component({ selector: 'angular-console-test-cmp', template: '' })
+class TestComponent {}
+
+@NgModule({
+  declarations: [TestComponent],
+  imports: [RouterTestingModule]
+})
+class TestSharedModule {}
+
+const testRoutes: Routes = [
+  {
+    path: ':id',
+    component: TestComponent
+  }
+];
+
+describe('RouterNavigationService', () => {
+  beforeEach(() => {
+    TestBed.resetTestEnvironment();
+
+    TestBed.initTestEnvironment(
+      BrowserDynamicTestingModule,
+      platformBrowserDynamicTesting()
+    ).configureTestingModule({
+      providers: [RouterNavigationService],
+      imports: [TestSharedModule, RouterTestingModule.withRoutes(testRoutes)]
+    });
+  });
+
+  it('navigates to fallback route if unable to go back', fakeAsync(async () => {
+    const service: RouterNavigationService = TestBed.get(
+      RouterNavigationService
+    );
+
+    const injector = getTestBed();
+    const router = injector.get(Router);
+    const fixture = TestBed.createComponent(TestComponent);
+    const visited = [] as string[];
+    const sub = router.events
+      .pipe(
+        filter(evt => {
+          return evt instanceof NavigationEnd;
+        })
+      )
+      .subscribe((evt: NavigationEnd) => {
+        visited.push(evt.url);
+      });
+    fixture.detectChanges();
+
+    await service.goBackOrNavigateToFallback(['/1']);
+
+    expect(visited).toEqual(['/1']);
+
+    sub.unsubscribe();
+  }));
+});

--- a/libs/utils/src/lib/router-navigation.service.ts
+++ b/libs/utils/src/lib/router-navigation.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Router, NavigationEnd, NavigationExtras } from '@angular/router';
+import { filter, skip, take } from 'rxjs/operators';
+import { Location } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RouterNavigationService implements OnDestroy {
+  private isFirstRoute = true;
+
+  additionalNavigationSubscription = this.router.events
+    .pipe(
+      filter(evt => {
+        return evt instanceof NavigationEnd;
+      }),
+      skip(1),
+      take(1)
+    )
+    .subscribe(() => {
+      this.isFirstRoute = false;
+    });
+
+  constructor(
+    private readonly router: Router,
+    private readonly location: Location
+  ) {}
+
+  ngOnDestroy() {
+    this.additionalNavigationSubscription.unsubscribe();
+  }
+
+  async goBackOrNavigateToFallback(fallback: any[], extras?: NavigationExtras) {
+    if (this.isFirstRoute) {
+      await this.router.navigate(fallback, extras);
+    } else {
+      this.location.back();
+    }
+  }
+}


### PR DESCRIPTION
**Assumption:** There is always a location to go back to (which is true for this desktop app)

**Note:** There is a small delay in updating sidenav as seen below.

![tasks](https://user-images.githubusercontent.com/53559/49660875-a6882e80-fa15-11e8-9f05-e6e42750951a.gif)


- Closes #435