### PR TITLE
feat: add ngxs schematics package to extension list

### DIFF
--- a/server/src/api/read-extensions.ts
+++ b/server/src/api/read-extensions.ts
@@ -42,6 +42,10 @@ export function availableExtensions() {
       description: 'NgRx state management generators'
     },
     {
+      name: '@ngxs/schematics',
+      description: 'Ngxs state management schematics'
+    },
+    {
       name: '@progress/kendo-angular-conversational-ui',
       description: 'Kendo UI Conversational components'
     },


### PR DESCRIPTION
@ngxs/schematics has been updated for compatibility with Angular console so adding to extension list

Closes #204