### PR TITLE
fix: Use defaults from angular.json in generate form

### DIFF
--- a/apps/angular-console-e2e/src/integration/generate.spec.ts
+++ b/apps/angular-console-e2e/src/integration/generate.spec.ts
@@ -58,7 +58,14 @@ describe('Generate', () => {
 
     const name = uniqName('example');
     cy.get('input[name="name"]').type(name);
-    cy.get('input[name="project"]').type('proj');
+    cy.get('input[name="project"]').type('proj{esc}');
+
+    cy.contains('Optional fields').click();
+    cy.get('mat-select[name="flat"]')
+      .contains('false')
+      .click();
+    cy.contains('mat-option', 'true').click();
+    cy.get('mat-select[name="flat"]').contains('true');
 
     cy.wait(100);
 
@@ -69,7 +76,7 @@ describe('Generate', () => {
     cy.wait(100);
 
     checkDisplayedCommand(
-      `ng generate @schematics/angular:service ${name} --project=proj`
+      `ng generate @schematics/angular:service ${name} --project=proj --flat`
     );
     checkFileExists(`src/app/${name}.service.ts`);
     checkFileExists(`src/app/${name}.service.spec.ts`);

--- a/libs/server/src/lib/api/read-schematic-collections.spec.ts
+++ b/libs/server/src/lib/api/read-schematic-collections.spec.ts
@@ -1,11 +1,12 @@
-import { canAdd } from '../../src/api/read-schematic-collections';
+import { canAdd } from './read-schematic-collections';
 
 describe('readAllSchematicCollections', () => {
   describe('canAdd', () => {
     const VALID_SCHEMATIC_TO_ADD = {
       private: false,
       hidden: false,
-      schema: 'schema'
+      schema: 'schema',
+      extends: false
     };
 
     it('should include a valid schematic', () => {

--- a/tools/scripts/set-up-e2e-fixtures.js
+++ b/tools/scripts/set-up-e2e-fixtures.js
@@ -2,6 +2,7 @@ const cp = require('child_process');
 const shell = require('shelljs');
 const tmp = shell.tempdir();
 const path = require('path');
+const fs = require('fs');
 
 console.log(`setting up fixtures`);
 
@@ -19,18 +20,55 @@ shell.mkdir(path.join(tmp, 'proj-nx'));
 
 shell.rm('-rf', path.join(tmp, 'ng'));
 shell.mkdir(path.join(tmp, 'ng'));
-cp.execSync('yarn add @angular/cli@7.1.4', {cwd: path.join(tmp, 'ng')});
-cp.execSync('yarn add @nrwl/schematics@7.3.0', {cwd: path.join(tmp, 'ng')});
+cp.execSync('yarn add @angular/cli@7.1.4', { cwd: path.join(tmp, 'ng') });
+cp.execSync('yarn add @nrwl/schematics@7.3.0', { cwd: path.join(tmp, 'ng') });
 
 cp.execSync('ng config -g cli.packageManager yarn');
-cp.execSync(`${path.join(tmp, 'ng')}/node_modules/.bin/ng new proj --collection=@schematics/angular --directory=proj --skip-git --no-interactive`, { cwd: tmp, stdio: [0, 1, 2] });
+cp.execSync(
+  `${path.join(
+    tmp,
+    'ng'
+  )}/node_modules/.bin/ng new proj --collection=@schematics/angular --directory=proj --skip-git --no-interactive`,
+  { cwd: tmp, stdio: [0, 1, 2] }
+);
+const angularJson = JSON.parse(
+  fs.readFileSync(path.join(tmp, 'proj', 'angular.json')).toString()
+);
+angularJson.schematics = {
+  '@schematics/angular:service': {
+    flat: false
+  }
+};
+fs.writeFileSync(
+  path.join(tmp, 'proj', 'angular.json'),
+  JSON.stringify(angularJson, null, 2)
+);
+
 shell.mv(path.join(tmp, 'proj'), './tmp/proj');
 
-cp.execSync(`${path.join(tmp, 'ng')}/node_modules/.bin/ng new proj-extensions --collection=@schematics/angular --directory=proj-extensions --skip-git --no-interactive`, { cwd: tmp, stdio: [0, 1, 2] });
+cp.execSync(
+  `${path.join(
+    tmp,
+    'ng'
+  )}/node_modules/.bin/ng new proj-extensions --collection=@schematics/angular --directory=proj-extensions --skip-git --no-interactive`,
+  { cwd: tmp, stdio: [0, 1, 2] }
+);
 shell.mv(path.join(tmp, 'proj-extensions'), './tmp/proj-extensions');
 
-cp.execSync(`${path.join(tmp, 'ng')}/node_modules/.bin/ng new proj-no-node-modules --collection=@schematics/angular --directory=proj-no-node-modules --skip-install --skip-git --no-interactive`, { cwd: tmp, stdio: [0, 1, 2] });
+cp.execSync(
+  `${path.join(
+    tmp,
+    'ng'
+  )}/node_modules/.bin/ng new proj-no-node-modules --collection=@schematics/angular --directory=proj-no-node-modules --skip-install --skip-git --no-interactive`,
+  { cwd: tmp, stdio: [0, 1, 2] }
+);
 shell.mv(path.join(tmp, 'proj-no-node-modules'), './tmp/proj-no-node-modules');
 
-cp.execSync(`${path.join(tmp, 'ng')}/node_modules/.bin/ng new proj-nx --collection=@nrwl/schematics --directory=proj-nx --skip-git --no-interactive`, { cwd: tmp, stdio: [0, 1, 2] });
+cp.execSync(
+  `${path.join(
+    tmp,
+    'ng'
+  )}/node_modules/.bin/ng new proj-nx --collection=@nrwl/schematics --directory=proj-nx --skip-git --no-interactive`,
+  { cwd: tmp, stdio: [0, 1, 2] }
+);
 shell.mv(path.join(tmp, 'proj-nx'), './tmp/proj-nx');


### PR DESCRIPTION
Fix for #156 .

This takes the approach of overriding the `defaultValue` when the schema is normalized.
<img width="440" alt="screen shot 2018-12-21 at 15 26 58" src="https://user-images.githubusercontent.com/861504/50362219-e92d2900-0534-11e9-83a8-7bdde1269f68.png">

Another possible solution would be to keep the existing `defaultValue` and add a `projectDefault`, so that the initial value is set to the `projectDefault`, but the `defaultValue` from the schema definition is still displayed in the description.
![image](https://user-images.githubusercontent.com/861504/50362298-2c879780-0535-11e9-8c35-2c411e457ccb.png)
