### PR TITLE
feat: pinned projects

### DIFF
--- a/apps/angular-console-e2e/src/integration/projects.spec.ts
+++ b/apps/angular-console-e2e/src/integration/projects.spec.ts
@@ -42,4 +42,17 @@ describe('Projects', () => {
       expect(texts($p)[1]).to.contain('proj-e2e');
     });
   });
+  it('should pin and unpin projects', () => {
+    cy.get('.favorite-icon.favorited').should('not.exist');
+    cy.get('.favorite-icon:not(.favorited)')
+      .should('have.length', 2)
+      .first()
+      .click();
+    cy.get('.favorite-icon:not(.favorited)').should('have.length', 1);
+    cy.get('.favorite-icon.favorited')
+      .should('have.length', 1)
+      .click();
+    cy.get('.favorite-icon.favorited').should('not.exist');
+    cy.get('.favorite-icon:not(.favorited)').should('have.length', 2);
+  });
 });

--- a/libs/feature-workspaces/src/lib/projects/projects.component.html
+++ b/libs/feature-workspaces/src/lib/projects/projects.component.html
@@ -1,33 +1,40 @@
-<div *ngIf="(filteredProjects$ | async) as projects">
-  <div
-    class="project-filter-container"
-    fxLayout="row"
-    fxLayoutAlign="start center"
+<div
+  class="project-filter-container"
+  fxLayout="row"
+  fxLayoutAlign="start center"
+>
+  <input
+    placeholder="Filter projects..."
+    #projectFilter
+    fxFlex
+    [formControl]="projectFilterFormControl"
+    id="filter"
+  />
+  <mat-icon
+    class="filter-icon"
+    (click)="projectFilterFormControl.setValue(''); projectFilter.select()"
   >
-    <input
-      placeholder="Filter projects..."
-      #projectFilter
-      fxFlex
-      [formControl]="projectFilterFormControl"
-      id="filter"
-    />
-    <mat-icon
-      class="filter-icon"
-      (click)="projectFilterFormControl.setValue(''); projectFilter.select()"
-    >
-      {{ projectFilterFormControl.value ? 'clear' : 'filter_list' }}
-    </mat-icon>
-  </div>
-  <mat-list *ngIf="projects.length > 0">
-    <cdk-virtual-scroll-viewport
-      [style.height]="viewportHeight$ | async"
-      itemSize="88px"
-      class="field-viewport"
-    >
-      <ui-entity-docs [docs]="docs$ | async"></ui-entity-docs>
+    {{ projectFilterFormControl.value ? 'clear' : 'filter_list' }}
+  </mat-icon>
+</div>
+<mat-list>
+  <cdk-virtual-scroll-viewport
+    [style.height]="viewportHeight$ | async"
+    itemSize="88px"
+    class="field-viewport"
+  >
+    <ui-entity-docs [docs]="docs$ | async"></ui-entity-docs>
 
-      <ng-container *cdkVirtualFor="let p of projects">
+    <ng-container *ngIf="(filteredPinnedProjects$ | async) as projects">
+      <h3 *ngIf="projects.length > 0" mat-subheader>Pinned Projects</h3>
+      <ng-container *ngFor="let p of projects">
         <mat-list-item [ngClass]="p.projectType" [disableRipple]="true">
+          <mat-icon
+            (click)="onPinClick(p); $event.stopPropagation()"
+            mat-list-icon
+            class="favorite-icon favorited"
+            >favorite</mat-icon
+          >
           <div class="project-type" mat-line>{{ p.projectType }}</div>
           <div class="project-name" mat-line>{{ p.name }}</div>
           <div class="project-root" mat-line *ngIf="p.root">
@@ -52,6 +59,41 @@
         </mat-list-item>
         <mat-divider></mat-divider>
       </ng-container>
-    </cdk-virtual-scroll-viewport>
-  </mat-list>
-</div>
+    </ng-container>
+    <ng-container *ngIf="(filteredUnpinnedProjects$ | async) as projects">
+      <h3 mat-subheader>Projects</h3>
+      <ng-container *cdkVirtualFor="let p of projects">
+        <mat-list-item [ngClass]="p.projectType" [disableRipple]="true">
+          <mat-icon
+            (click)="onPinClick(p); $event.stopPropagation()"
+            mat-list-icon
+            class="favorite-icon"
+            >favorite_border</mat-icon
+          >
+          <div class="project-type" mat-line>{{ p.projectType }}</div>
+          <div class="project-name" mat-line>{{ p.name }}</div>
+          <div class="project-root" mat-line *ngIf="p.root">
+            <mat-icon>folder_open</mat-icon>
+            {{ p.root }}
+          </div>
+          <div
+            fxLayoutWrap
+            fxFlex="shrink"
+            fxLayout="row"
+            fxLayoutGap="12px"
+            fxLayoutAlign="end center"
+          >
+            <button
+              *ngFor="let a of p.actions"
+              mat-stroked-button
+              [routerLink]="a.link"
+            >
+              {{ a.actionDescription }}
+            </button>
+          </div>
+        </mat-list-item>
+        <mat-divider></mat-divider>
+      </ng-container>
+    </ng-container>
+  </cdk-virtual-scroll-viewport>
+</mat-list>

--- a/libs/feature-workspaces/src/lib/projects/projects.component.ts
+++ b/libs/feature-workspaces/src/lib/projects/projects.component.ts
@@ -77,7 +77,6 @@ export class ProjectsComponent implements OnInit {
           return {
             ...p,
             actions: this.createActions(p)
-            // pinned: this.pinnedProjectNames.includes(p.name)
           };
         });
         return projects;

--- a/libs/feature-workspaces/src/lib/projects/projects.component.ts
+++ b/libs/feature-workspaces/src/lib/projects/projects.component.ts
@@ -2,11 +2,12 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Project } from '@angular-console/schema';
 import { combineLatest, Observable, of } from 'rxjs';
-import { map, startWith, switchMap, shareReplay } from 'rxjs/operators';
+import { map, startWith, switchMap, shareReplay, tap } from 'rxjs/operators';
 import {
   PROJECTS_POLLING,
   Settings,
-  CommandRunner
+  CommandRunner,
+  toggleItemInArray
 } from '@angular-console/utils';
 import { WorkspaceDocsGQL, WorkspaceGQL } from '../generated/graphql';
 import { FormControl } from '@angular/forms';
@@ -18,8 +19,12 @@ import { FormControl } from '@angular/forms';
   styleUrls: ['./projects.component.scss']
 })
 export class ProjectsComponent implements OnInit {
-  projects$: Observable<any>;
-  filteredProjects$: Observable<any>;
+  workspacePath: string;
+  pinnedProjectNames: string[];
+  projects$: Observable<Project[]>;
+  filteredProjects$: Observable<Project[]>;
+  filteredPinnedProjects$: Observable<Project[]>;
+  filteredUnpinnedProjects$: Observable<Project[]>;
   docs$ = this.settings.showDocs
     ? this.route.params.pipe(
         switchMap(p => this.workspaceDocsGQL.fetch({ path: p.path })),
@@ -38,9 +43,9 @@ export class ProjectsComponent implements OnInit {
   );
 
   constructor(
+    readonly settings: Settings,
     private readonly route: ActivatedRoute,
     private readonly workspaceGQL: WorkspaceGQL,
-    private readonly settings: Settings,
     private readonly workspaceDocsGQL: WorkspaceDocsGQL,
     private readonly commandRunner: CommandRunner
   ) {}
@@ -48,6 +53,9 @@ export class ProjectsComponent implements OnInit {
   ngOnInit() {
     this.projects$ = this.route.params.pipe(
       map(m => m.path),
+      tap(path => {
+        this.workspacePath = path;
+      }),
       switchMap(path => {
         return this.workspaceGQL.watch(
           {
@@ -60,8 +68,17 @@ export class ProjectsComponent implements OnInit {
       }),
       map((r: any) => {
         const w = r.data.workspace;
-        const projects = w.projects.map((p: any) => {
-          return { ...p, actions: this.createActions(p) };
+        const workspaceSettings = this.settings.getWorkspace(
+          this.workspacePath
+        );
+        this.pinnedProjectNames =
+          (workspaceSettings && workspaceSettings.pinnedProjectNames) || [];
+        const projects: Project[] = w.projects.map((p: Project) => {
+          return {
+            ...p,
+            actions: this.createActions(p)
+            // pinned: this.pinnedProjectNames.includes(p.name)
+          };
         });
         return projects;
       })
@@ -80,6 +97,21 @@ export class ProjectsComponent implements OnInit {
         )
       )
     );
+
+    this.filteredPinnedProjects$ = this.filteredProjects$.pipe(
+      map(projects =>
+        projects.filter(project =>
+          this.pinnedProjectNames.includes(project.name)
+        )
+      )
+    );
+    this.filteredUnpinnedProjects$ = this.filteredProjects$.pipe(
+      map(projects =>
+        projects.filter(
+          project => !this.pinnedProjectNames.includes(project.name)
+        )
+      )
+    );
   }
 
   private createActions(p: any) {
@@ -92,7 +124,18 @@ export class ProjectsComponent implements OnInit {
     ] as any[];
   }
 
-  trackByName(p: any) {
+  onPinClick(p: Project) {
+    this.pinnedProjectNames = toggleItemInArray(
+      this.pinnedProjectNames || [],
+      p.name
+    );
+    this.projectFilterFormControl.setValue(
+      this.projectFilterFormControl.value || ''
+    );
+    this.settings.toggleProjectPin(this.workspacePath, p);
+  }
+
+  trackByName(p: Project) {
     return p.name;
   }
 }

--- a/libs/feature-workspaces/src/lib/workspace/workspace.component.ts
+++ b/libs/feature-workspaces/src/lib/workspace/workspace.component.ts
@@ -174,7 +174,12 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   });
 
   private readonly subscription = this.workspace$.subscribe(w => {
-    this.settings.addRecent({ name: w.name, path: w.path, favorite: false });
+    this.settings.addRecent({
+      name: w.name,
+      path: w.path,
+      favorite: false,
+      pinnedProjectNames: []
+    });
   });
 
   readonly isElectron = this.environment.application === 'electron';

--- a/libs/schema/src/lib/generated/graphql-types.ts
+++ b/libs/schema/src/lib/generated/graphql-types.ts
@@ -57,7 +57,7 @@ export interface WorkspaceDefinition {
 
   favorite?: Maybe<boolean>;
 
-  pinnedProjectNames?: Maybe<string[]>;
+  pinnedProjectNames: string[];
 }
 
 export interface SchematicCollectionForNgNew {
@@ -719,7 +719,7 @@ export namespace WorkspaceDefinitionResolvers {
     favorite?: FavoriteResolver<Maybe<boolean>, TypeParent, Context>;
 
     pinnedProjectNames?: PinnedProjectNamesResolver<
-      Maybe<string[]>,
+      string[],
       TypeParent,
       Context
     >;
@@ -741,7 +741,7 @@ export namespace WorkspaceDefinitionResolvers {
     Context = any
   > = Resolver<R, Parent, Context>;
   export type PinnedProjectNamesResolver<
-    R = Maybe<string[]>,
+    R = string[],
     Parent = any,
     Context = any
   > = Resolver<R, Parent, Context>;

--- a/libs/schema/src/lib/generated/graphql-types.ts
+++ b/libs/schema/src/lib/generated/graphql-types.ts
@@ -56,6 +56,8 @@ export interface WorkspaceDefinition {
   name: string;
 
   favorite?: Maybe<boolean>;
+
+  pinnedProjectNames?: Maybe<string[]>;
 }
 
 export interface SchematicCollectionForNgNew {
@@ -715,6 +717,12 @@ export namespace WorkspaceDefinitionResolvers {
     name?: NameResolver<string, TypeParent, Context>;
 
     favorite?: FavoriteResolver<Maybe<boolean>, TypeParent, Context>;
+
+    pinnedProjectNames?: PinnedProjectNamesResolver<
+      Maybe<string[]>,
+      TypeParent,
+      Context
+    >;
   }
 
   export type PathResolver<R = string, Parent = any, Context = any> = Resolver<
@@ -729,6 +737,11 @@ export namespace WorkspaceDefinitionResolvers {
   >;
   export type FavoriteResolver<
     R = Maybe<boolean>,
+    Parent = any,
+    Context = any
+  > = Resolver<R, Parent, Context>;
+  export type PinnedProjectNamesResolver<
+    R = Maybe<string[]>,
     Parent = any,
     Context = any
   > = Resolver<R, Parent, Context>;

--- a/libs/server/src/assets/schema.graphql
+++ b/libs/server/src/assets/schema.graphql
@@ -219,7 +219,7 @@ type WorkspaceDefinition {
   path: String!
   name: String!
   favorite: Boolean
-  pinnedProjectNames: [String!]
+  pinnedProjectNames: [String!]!
 }
 
 type Settings {

--- a/libs/server/src/assets/schema.graphql
+++ b/libs/server/src/assets/schema.graphql
@@ -219,6 +219,7 @@ type WorkspaceDefinition {
   path: String!
   name: String!
   favorite: Boolean
+  pinnedProjectNames: [String!]
 }
 
 type Settings {

--- a/libs/utils/src/lib/graphql/settings.graphql
+++ b/libs/utils/src/lib/graphql/settings.graphql
@@ -9,6 +9,7 @@ query Settings {
       path
       name
       favorite
+      pinnedProjectNames
     }
   }
 }

--- a/libs/utils/src/lib/graphql/update-settings.graphql
+++ b/libs/utils/src/lib/graphql/update-settings.graphql
@@ -8,6 +8,7 @@ mutation UpdateSettings($data: String!) {
       path
       name
       favorite
+      pinnedProjectNames
     }
   }
 }

--- a/libs/utils/src/lib/settings.service.spec.ts
+++ b/libs/utils/src/lib/settings.service.spec.ts
@@ -24,14 +24,24 @@ describe('Settings', () => {
   });
 
   it('should not add the same project twice', () => {
-    settings.addRecent({ name: 'one', path: 'one', favorite: true });
+    settings.addRecent({
+      name: 'one',
+      path: 'one',
+      favorite: true,
+      pinnedProjectNames: []
+    });
     expect(settings.getRecentWorkspaces()).toEqual([
-      { name: 'one', path: 'one', favorite: true }
+      { name: 'one', path: 'one', favorite: true, pinnedProjectNames: [] }
     ]);
 
-    settings.addRecent({ name: 'one', path: 'one' });
+    settings.addRecent({
+      name: 'one',
+      path: 'one',
+      favorite: true,
+      pinnedProjectNames: []
+    });
     expect(settings.getRecentWorkspaces()).toEqual([
-      { name: 'one', path: 'one', favorite: true }
+      { name: 'one', path: 'one', favorite: true, pinnedProjectNames: [] }
     ]);
   });
 });

--- a/libs/utils/src/lib/settings.service.ts
+++ b/libs/utils/src/lib/settings.service.ts
@@ -7,6 +7,13 @@ import {
 } from './generated/graphql';
 
 export { Settings as SettingsModels } from './generated/graphql';
+import { Project } from '@angular-console/schema';
+
+export function toggleItemInArray<T>(array: T[], item: T): T[] {
+  return array.includes(item)
+    ? array.filter(value => value !== item)
+    : [...array, item];
+}
 
 @Injectable({
   providedIn: 'root'
@@ -38,10 +45,31 @@ export class Settings {
     }
   }
 
+  getWorkspace(path: string): SettingsModels.Recent | undefined {
+    return (this.settings.recent || []).find(w => w.path === path);
+  }
+
   toggleFavorite(w: SettingsModels.Recent): void {
     const r = this.getRecentWorkspaces().filter(rr => rr.path !== w.path);
     const favorite: SettingsModels.Recent = { ...w, favorite: !w.favorite };
     this.store({ ...this.settings, recent: [...r, favorite] });
+  }
+
+  toggleProjectPin(path: string, project: Project): void {
+    const workspace = this.getWorkspace(path);
+    if (!workspace) {
+      console.warn('No workspace found at path: ', path);
+      return;
+    }
+    const r = this.getRecentWorkspaces().filter(rr => rr.path !== path);
+    const modifiedWorkspace: SettingsModels.Recent = {
+      ...workspace,
+      pinnedProjectNames: toggleItemInArray(
+        workspace.pinnedProjectNames || [],
+        project.name
+      )
+    };
+    this.store({ ...this.settings, recent: [...r, modifiedWorkspace] });
   }
 
   addRecent(w: SettingsModels.Recent): void {

--- a/libs/utils/src/lib/settings.service.ts
+++ b/libs/utils/src/lib/settings.service.ts
@@ -34,7 +34,13 @@ export class Settings {
   ) {}
 
   getRecentWorkspaces(favorite?: boolean): SettingsModels.Recent[] {
-    const all: SettingsModels.Recent[] = this.settings.recent || [];
+    const all: SettingsModels.Recent[] =
+      this.settings.recent.map(w => {
+        if (!w.pinnedProjectNames) {
+          w.pinnedProjectNames = [];
+        }
+        return w;
+      }) || [];
     switch (favorite) {
       case undefined:
         return all;


### PR DESCRIPTION
Allow pinning on the projects page

1. When the component is loaded, the `pinnedProjectNames` are loaded from the settings service.  Any modifications are saved locally in the component and updated in settings.  Reloading the component will load the graphql settings version.  

    **Alternative:**  I could make the settings service return an Observable of the workspace settings to avoid having any local component state.

2. I tried copying the `@growShrink` animation from the `workspaces` component, but that does not appear to play nicely with `<cdk-virtual-scroll-viewport>`