### PR TITLE
fix(intellij): exclude *.zip file from the buildPlugin process

### DIFF
--- a/apps/intellij/build.gradle
+++ b/apps/intellij/build.gradle
@@ -68,7 +68,7 @@ project.afterEvaluate {
 
     copy {
       from("$distApps") {
-        exclude('**/*.ts', '**/*.md', 'app', 'java', 'resources', 'environments')
+        exclude('**/*.ts', '**/*.zip', '**/*.md', 'app', 'java', 'resources', 'environments')
       }
       into "$project.projectDir/gen/ngConsoleCli"
     }
@@ -92,7 +92,7 @@ project.afterEvaluate {
 
     copy {
       from("$distApps") {
-        exclude('**/*.ts', '**/*.md', 'app', 'java', 'resources', 'environments')
+        exclude('**/*.ts', '**/*.zip', '**/*.md', 'app', 'java', 'resources', 'environments')
       }
       into "$project.projectDir/gen/ngConsoleCli"
     }


### PR DESCRIPTION
This make sure it does not include `Angular Console-X.X.X.zip `from `dist/apps/intellij `into the gradle build process `buildPlugin`.
 

