### PR TITLE
fix: Use initial pathname from window.location if object exist so we …

### DIFF
--- a/apps/angular-console/src/environments/environment.cypress.ts
+++ b/apps/angular-console/src/environments/environment.cypress.ts
@@ -4,8 +4,6 @@ import { of } from 'rxjs';
 import { PlatformLocation } from '@angular/common';
 import { InMemoryPlatformLocation } from '@angular-console/utils';
 
-declare const window: Window;
-
 class MockGetDirectoryPathGQL extends GetDirectoryPathGQL {
   mutate() {
     return of({
@@ -24,7 +22,6 @@ export const environment: Environment = {
   application: 'electron',
   disableAnimations: true,
   providers: [
-    { provide: 'INITIAL_PATHNAME', useValue: window.location.pathname },
     {
       provide: PlatformLocation,
       useClass: InMemoryPlatformLocation

--- a/libs/utils/src/lib/in-memory-platform-location.service.ts
+++ b/libs/utils/src/lib/in-memory-platform-location.service.ts
@@ -1,5 +1,5 @@
 import { LocationChangeListener, PlatformLocation } from '@angular/common';
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Injectable } from '@angular/core';
 import * as url from 'url';
 
 function parseUrl(
@@ -13,17 +13,16 @@ function parseUrl(
   };
 }
 
+declare const window: Window | null;
+
 @Injectable()
 export class InMemoryPlatformLocation implements PlatformLocation {
-  readonly pathname: string = '/';
+  readonly pathname: string =
+    window && window.location ? window.location.pathname : '/';
   readonly search: string = '';
   readonly hash: string = '';
 
-  constructor(@Optional() @Inject('INITIAL_PATHNAME') pathname: string) {
-    if (pathname) {
-      (this as { pathname: string }).pathname = pathname;
-    }
-  }
+  constructor() {}
 
   getBaseHrefFromDOM(): string {
     // Always return the same base href since we will never set it in document.


### PR DESCRIPTION
…can deep link into individual routes.