### PR TITLE
fix(vscode): Set default font color to override vscode default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,6 @@
       "sourceMaps": false,
       "stopOnEntry": false,
       "outFiles": ["${workspaceFolder}/**/*"],
-      "preLaunchTask": "npm: build-vs-code"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,13 +42,13 @@ You can build the electron app by running `yarn start package.electronMac` or `y
 
 ## Building VSCode Plugin
 
-You can build the vscode extension by running `yarn start package.vscode`.
+You can build the vscode extension by running `yarn start prepare.and.package.vscode`.
 You can install it by running `code --install-extension dist/apps/vscode/angular-console.vsix`
 Reload the vscode window to use the newly installed build of the extension.
 
 If you are working on the plugin, run:
 
-- `yarn start prepare.vscode`
+- `yarn start prepare.dev.vscode`
 - Hit F5
 
 ## Submitting a PR

--- a/apps/angular-console/src/styles.scss
+++ b/apps/angular-console/src/styles.scss
@@ -22,6 +22,7 @@ body {
   padding: 0;
   background: white;
   overflow: hidden;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 button.mat-button,

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -160,7 +160,16 @@ module.exports = {
           'install-dependencies.APPLICATION',
           'dev.copy-assets.APPLICATION'
         )
-      )
+      ),
+      dev: {
+        ...forEachApplication(
+          nps.series.nps(
+            'clean',
+            'build.APPLICATION.dev',
+            'dev.copy-assets-base.APPLICATION'
+          )
+        )
+      }
     },
     package: {
       electronMac: nps.series(
@@ -231,7 +240,18 @@ module.exports = {
             client: 'ng build angular-console --configuration=APPLICATION'
           })
         )
-      )
+      ),
+      dev: {
+        ...forEachApplication(
+          nps.series(
+            'nps dev.gen-graphql',
+            nps.concurrent({
+              server: 'ng build APPLICATION --maxWorkers=4',
+              client: 'ng build angular-console --configuration=APPLICATION'
+            })
+          )
+        )
+      }
     },
     test: {
       default: 'nx affected:test --all --parallel',


### PR DESCRIPTION
Also implements `nps prepare.dev.vscode` to rebuild all vscode
dev artifcats more quickly than `nps prepare.vscode`