### PR TITLE
chore: organize scripts by app instead of target kinds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           paths:
             - ~/.cache
       - run: yarn start format.and.lint.check
-      - run: yarn start prepare.e2e
+      - run: yarn start e2e.prepare
       - run: yarn start test.affected.origin-master
       - run:
           command: yarn start e2e.ci1
@@ -45,7 +45,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - yarn-dependencies-12.2.0-
       - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn start prepare.e2e
+      - run: yarn start e2e.prepare
       - run:
           command: yarn start e2e.ci2
           no_output_timeout: 5m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The two versions of Angular Console share most of the code, but they are bundled
 
 After cloning the project run: `yarn`.
 
-After that, run `yarn start prepare.electron`. Every time you add or remove dependencies in electron/package.json, you will need to rerun `prepare.electron`.
+After that, run `yarn start electron.prepare`. Every time you add or remove dependencies in electron/package.json, you will need to rerun `electron.prepare`.
 
 After this, run `yarn start dev.up` to start the dev environment. The application will start the process listening on port 4200. The development is done in the browser, but the server uses electron.
 
@@ -38,7 +38,7 @@ Cypress, which we use to run e2e tests, records the videos of the tests ran on C
 
 ## Building Electron App
 
-You can build the electron app by running `yarn start package.electronMac` or `yarn start package.electronWin`. Usually, you only need to do it locally if you change something related to electron-builder.
+You can build the electron app by running `yarn start electron.package`. Usually, you only need to do it locally if you change something related to electron-builder.
 
 ## Building VSCode Plugin
 
@@ -48,7 +48,7 @@ Reload the vscode window to use the newly installed build of the extension.
 
 If you are working on the plugin, run:
 
-- `yarn start prepare.dev.vscode`
+- `yarn start vscode.prepare.dev`
 - Hit F5
 
 ## Submitting a PR

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,12 +1,241 @@
 const nps = require('nps-utils');
-const os = require('os');
+const { platform } = require('os');
 const { join } = require('path');
 
-function forEachApplication(command) {
-  return {
-    electron: command.replace(/APPLICATION/g, 'electron'),
-    intellij: command.replace(/APPLICATION/g, 'intellij'),
-    vscode: command.replace(/APPLICATION/g, 'vscode')
+const APPS_PATH = join('dist', 'apps');
+const ELECTRON_BUNDLE_PATH = join(APPS_PATH, 'electron');
+
+module.exports = {
+  scripts: pipe(
+    always({
+      'gen-graphql': nps.series(
+        'gql-gen --config ./tools/scripts/codegen-server.yml',
+        'gql-gen --config ./tools/scripts/codegen-client.js'
+      ),
+      clean: 'shx rm -rf dist/',
+      e2e: {
+        prepare: {
+          default: nps.concurrent.nps('electron.prepare', 'e2e.fixtures'),
+          and: {
+            up: nps.series.nps('e2e.prepare', 'e2e.up'),
+            headless: nps.series.nps('e2e.prepare', 'e2e.headless'),
+            'check-formatting': nps.concurrent.nps(
+              'e2e.prepare',
+              'format.and.lint.check'
+            )
+          }
+        },
+        fixtures: 'node ./tools/scripts/set-up-e2e-fixtures.js',
+        up: 'node ./tools/scripts/e2e.js --watch',
+        headless: {
+          default: 'node ./tools/scripts/e2e.js --headless',
+          'new-fixtures': nps.series.nps('e2e.prepare', 'e2e.headless')
+        },
+        ci1: 'node ./tools/scripts/e2e.js --headless --configuration=ci1',
+        ci2: 'node ./tools/scripts/e2e.js --headless --configuration=ci2',
+        ci3: 'node ./tools/scripts/e2e.js --headless --configuration=ci3'
+      },
+      format: {
+        default: 'nx format:write',
+        and: {
+          lint: {
+            check: nps.concurrent.nps('format.check', 'lint')
+          }
+        },
+        write: 'nx format:write',
+        check: 'nx format:check'
+      },
+      lint: {
+        default: nps.concurrent({
+          nxLint: 'nx lint',
+          tsLint:
+            'npx tslint -p tsconfig.json -e **/generated/* -c tslint.json',
+          stylelint: 'stylelint "{apps,libs}/**/*.scss" --config .stylelintrc'
+        }),
+        fix: nps.concurrent({
+          tslint:
+            'npx tslint -p tsconfig.json -e **/generated/* -c tslint.json --fix',
+          stylelint:
+            'stylelint "{apps,libs}/**/*.scss" --config .stylelintrc --fix'
+        })
+      },
+      test: {
+        default: 'nx affected:test --all --parallel',
+        affected: affected('test')
+      },
+      build: {
+        default: 'nx affected:build --all --parallel',
+        affected: affected('build')
+      },
+      dev: {
+        server: {
+          default: nps.series(
+            'nps gen-graphql',
+            'ng build electron --maxWorkers=4 --noSourceMap',
+            'nps electron.copy-assets',
+            'nps dev.server.start'
+          ),
+          start: `electron ${ELECTRON_BUNDLE_PATH} --server --port 4201 --inspect=9229`
+        },
+        up: {
+          default: nps.concurrent({
+            server: 'nps dev.server',
+            frontend: 'ng serve angular-console --configuration=dev'
+          }),
+          start: nps.concurrent({
+            server: 'nps dev.server.start',
+            frontend: 'ng serve angular-console --configuration=dev'
+          }),
+          cypress: nps.concurrent({
+            server: 'nps dev.server.start',
+            frontend: 'ng run angular-console:serve:cypress'
+          })
+        }
+      }
+    }),
+    withApp('electron', ({ name }) => ({
+      'install-dependencies': `node ${join(
+        'tools',
+        'scripts',
+        'electron-yarn.js'
+      )}`,
+      'copy-assets': nps.series(
+        `nps ${name}.copy-assets-base`,
+        `shx chmod 0755 ${join(
+          'dist',
+          'apps',
+          name,
+          'assets',
+          'new-workspace'
+        )}`
+      ),
+      package: {
+        default:
+          platform() === 'win32'
+            ? `nps ${name}.package.win`
+            : `nps ${name}.package.mac`,
+        mac: nps.series(
+          'echo "${CSC_LINK:?Need to set CSC_LINK non-empty}" > /dev/null',
+          electronBuilder('--mac', 'never'),
+          electronBuilder('--linux', 'never')
+        ),
+        win: electronBuilder('--win', 'never')
+      },
+      publish: {
+        win: nps.series(
+          `nps ${name}.prepare`,
+          electronBuilder(
+            '--win',
+            'always',
+            '--config.win.certificateSubjectName="Narwhal Technologies Inc."'
+          )
+        )
+      }
+    })),
+    withApp('intellij', () => ({
+      'install-dependencies': `node ${join(
+        'tools',
+        'scripts',
+        'intellij-yarn.js'
+      )}`,
+      package: `node ${join('tools', 'scripts', 'intellij-package.js')}`
+    })),
+    withApp('vscode', ({ name, assets }) => ({
+      'install-dependencies': `node ${join(
+        'tools',
+        'scripts',
+        'vscode-yarn.js'
+      )}`,
+      'copy-assets': nps.series(
+        `nps ${name}.copy-assets-base`,
+        `shx rm -rf ${assets['node-pty-prebuilt'].to}]`,
+        `shx cp -rf ${assets['node-pty-prebuilt'].from} ${
+          assets['node-pty-prebuilt'].to
+        }`
+      ),
+      package: nps.series(
+        `shx rm -rf ${join('dist', 'apps', name, '**', '*.ts')}`,
+        `node ${join('tools', 'scripts', 'vscode-vsce.js')}`
+      )
+    }))
+  ).call()
+};
+
+function pipe(...fns) {
+  return fns.reduce((a, b) => x => b(a(x)));
+}
+
+function always(x) {
+  return () => x;
+}
+
+function withApp(appName, getScripts) {
+  const appAssets = assetMappings(appName);
+  const appScripts = getScripts({ assets: appAssets, name: appName });
+
+  if (!appScripts['copy-assets']) {
+    appScripts['copy-assets'] = `nps ${appName}.copy-assets-base`;
+  }
+
+  if (!appScripts['install-dependencies']) {
+    throw new Error(
+      `Scripts for "${appName}" does not include "install-dependencies". Please check usage of \`withApp\`.`
+    );
+  }
+
+  return chainedScripts => {
+    return {
+      ...chainedScripts,
+      [appName]: {
+        ...appScripts,
+        'copy-assets-base': nps.concurrent({
+          schema: `shx cp ${appAssets['schema'].from} ${
+            appAssets['schema'].to
+          }`,
+          'server-assets': `shx cp -rf ${appAssets['server-assets'].from} ${
+            appAssets['server-assets'].to
+          }`,
+          readme: `shx cp ${appAssets['readme'].from} ${
+            appAssets['readme'].to
+          }`,
+          'extensions-schema': `shx cp ${appAssets['extensions-schema'].from} ${
+            appAssets['extensions-schema'].to
+          }`,
+          cli: 'node ./tools/scripts/patch-cli.js'
+        }),
+        build: {
+          default: nps.series(
+            'nps gen-graphql',
+            nps.concurrent({
+              server: `ng build ${appName} --prod --maxWorkers=4 --noSourceMap`,
+              client: `ng build angular-console --configuration=${appName}`
+            })
+          ),
+          dev: nps.series(
+            'nps gen-graphql',
+            nps.concurrent({
+              server: `ng build ${appName} --maxWorkers=4`,
+              client: `ng build angular-console --configuration=${appName}`
+            })
+          )
+        },
+        prepare: {
+          dev: nps.series.nps(
+            `${appName}.build.dev`,
+            `${appName}.copy-assets-base`
+          ),
+          default: nps.series.nps(
+            'clean',
+            `${appName}.build`,
+            `${appName}.install-dependencies`,
+            `${appName}.copy-assets`
+          ),
+          and: {
+            package: nps.series.nps(`${appName}.prepare`, `${appName}.package`)
+          }
+        }
+      }
+    };
   };
 }
 
@@ -23,245 +252,42 @@ function electronBuilder(platform, dashP, extraFlags) {
   }`;
 }
 
-const ELECTRON_BUNDLE_PATH = join('dist', 'apps', 'electron');
-const APPLICATION_BUNDLE_PATH = join('dist', 'apps', 'APPLICATION');
-
-const assetMappings = {
-  'node-pty-prebuilt': {
-    from: join('tools', 'win', 'node-pty-prebuilt', 'build', 'Release'),
-    to: join(
-      APPLICATION_BUNDLE_PATH,
-      'node_modules',
-      'node-pty-prebuilt',
-      'build'
-    )
-  },
-  'extensions-schema': {
-    from: join(
-      './node_modules',
-      '@nrwl',
-      'angular-console-enterprise-electron',
-      'schema.graphql'
-    ),
-    to: join(APPLICATION_BUNDLE_PATH, 'assets', 'extensions-schema.graphql')
-  },
-  'server-assets': {
-    from: join('libs', 'server', 'src', 'assets', '*'),
-    to: join(APPLICATION_BUNDLE_PATH, 'assets')
-  },
-  readme: {
-    from: 'README.md',
-    to: join(APPLICATION_BUNDLE_PATH, 'README.md')
-  },
-  schema: {
-    from: join(
-      'node_modules',
-      '@nrwl',
-      'angular-console-enterprise-electron',
-      'schema.graphql'
-    ),
-    to: join(
-      APPLICATION_BUNDLE_PATH,
-      'assets',
-      'angular-console-enterprise-electron-schema.graphql'
-    )
-  }
-};
-
-module.exports = {
-  scripts: {
-    dev: {
-      'copy-assets': {
-        electron: nps.series(
-          'nps dev.copy-assets-base.electron',
-          `shx chmod 0755 ${join(
-            'dist',
-            'apps',
-            'electron',
-            'assets',
-            'new-workspace'
-          )}`
-        ),
-        vscode: nps.series(
-          'nps dev.copy-assets-base.vscode',
-          `shx rm -rf ${assetMappings['node-pty-prebuilt'].to}]`,
-          `shx cp -rf ${assetMappings['node-pty-prebuilt'].from} ${
-            assetMappings['node-pty-prebuilt'].to
-          }`.replace(/APPLICATION/g, 'vscode')
-        )
-      },
-      'copy-assets-base': forEachApplication(
-        nps.concurrent({
-          schema: `shx cp ${assetMappings['schema'].from} ${
-            assetMappings['schema'].to
-          }`,
-          'server-assets': `shx cp -rf ${assetMappings['server-assets'].from} ${
-            assetMappings['server-assets'].to
-          }`,
-          readme: `shx cp ${assetMappings['readme'].from} ${
-            assetMappings['readme'].to
-          }`,
-          'extensions-schema': `shx cp ${
-            assetMappings['extensions-schema'].from
-          } ${assetMappings['extensions-schema'].to}`,
-          cli: 'node ./tools/scripts/patch-cli.js'
-        })
-      ),
-      'gen-graphql': nps.series(
-        'gql-gen --config ./tools/scripts/codegen-server.yml',
-        'gql-gen --config ./tools/scripts/codegen-client.js'
-      ),
-      server: {
-        default: nps.series(
-          'nps dev.gen-graphql',
-          'ng build electron --maxWorkers=4 --noSourceMap',
-          'nps dev.copy-assets.electron',
-          'nps dev.server.start'
-        ),
-        start: `electron ${ELECTRON_BUNDLE_PATH} --server --port 4201 --inspect=9229`
-      },
-      up: {
-        default: nps.concurrent({
-          server: 'nps dev.server',
-          frontend: 'ng serve angular-console --configuration=dev'
-        }),
-        start: nps.concurrent({
-          server: 'nps dev.server.start',
-          frontend: 'ng serve angular-console --configuration=dev'
-        }),
-        cypress: nps.concurrent({
-          server: 'nps dev.server.start',
-          frontend: 'ng run angular-console:serve:cypress'
-        })
-      }
+function assetMappings(appName) {
+  return {
+    'node-pty-prebuilt': {
+      from: join('tools', 'win', 'node-pty-prebuilt', 'build', 'Release'),
+      to: join(APPS_PATH, appName, 'node_modules', 'node-pty-prebuilt', 'build')
     },
-    clean: 'shx rm -rf dist/',
-    prepare: {
-      and: {
-        e2e: {
-          up: nps.series.nps('prepare.e2e', 'e2e.up'),
-          headless: nps.series.nps('prepare.e2e', 'e2e.headless')
-        },
-        package: {
-          ...forEachApplication(
-            nps.series.nps('prepare.APPLICATION', 'package.APPLICATION')
-          )
-        }
-      },
-      e2e: {
-        default: nps.concurrent.nps('prepare.electron', 'e2e.fixtures'),
-        and: {
-          'check-formatting': nps.concurrent.nps(
-            'prepare.e2e',
-            'format.and.lint.check'
-          )
-        }
-      },
-      ...forEachApplication(
-        nps.series.nps(
-          'build.APPLICATION',
-          'install-dependencies.APPLICATION',
-          'dev.copy-assets.APPLICATION'
-        )
+    'extensions-schema': {
+      from: join(
+        './node_modules',
+        '@nrwl',
+        'angular-console-enterprise-electron',
+        'schema.graphql'
       ),
-      dev: {
-        ...forEachApplication(
-          nps.series.nps(
-            'build.APPLICATION.dev',
-            'dev.copy-assets-base.APPLICATION'
-          )
-        )
-      }
+      to: join(APPS_PATH, appName, 'assets', 'extensions-schema.graphql')
     },
-    package: {
-      electronMac: nps.series(
-        'echo "${CSC_LINK:?Need to set CSC_LINK non-empty}" > /dev/null',
-        electronBuilder('--mac', 'never'),
-        electronBuilder('--linux', 'never')
-      ),
-      electronWin: nps.series(electronBuilder('--win', 'never')),
-      vscode: nps.series(
-        `shx rm -rf ${join('dist', 'apps', 'vscode', '**', '*.ts')}`,
-        `node ${join('tools', 'scripts', 'vscode-vsce.js')}`
-      ),
-      intellij: `node ${join('tools', 'scripts', 'intellij-package.js')}`
+    'server-assets': {
+      from: join('libs', 'server', 'src', 'assets', '*'),
+      to: join(APPS_PATH, appName, 'assets')
     },
-    publish: {
-      electronWin: nps.series(
-        'nps prepare.electron',
-        electronBuilder(
-          '--win',
-          'always',
-          '--config.win.certificateSubjectName="Narwhal Technologies Inc."'
-        )
+    readme: {
+      from: 'README.md',
+      to: join(APPS_PATH, appName, 'README.md')
+    },
+    schema: {
+      from: join(
+        'node_modules',
+        '@nrwl',
+        'angular-console-enterprise-electron',
+        'schema.graphql'
+      ),
+      to: join(
+        APPS_PATH,
+        appName,
+        'assets',
+        'angular-console-enterprise-electron-schema.graphql'
       )
-    },
-    e2e: {
-      fixtures: 'node ./tools/scripts/set-up-e2e-fixtures.js',
-      up: 'node ./tools/scripts/e2e.js --watch',
-      headless: {
-        default: 'node ./tools/scripts/e2e.js --headless',
-        'new-fixtures': nps.series.nps('prepare.e2e', 'e2e.headless')
-      },
-      ci1: 'node ./tools/scripts/e2e.js --headless --configuration=ci1',
-      ci2: 'node ./tools/scripts/e2e.js --headless --configuration=ci2',
-      ci3: 'node ./tools/scripts/e2e.js --headless --configuration=ci3'
-    },
-    format: {
-      default: 'nx format:write',
-      and: {
-        lint: {
-          check: nps.concurrent.nps('format.check', 'lint')
-        }
-      },
-      write: 'nx format:write',
-      check: 'nx format:check'
-    },
-    lint: {
-      default: nps.concurrent({
-        nxLint: 'nx lint',
-        tsLint: 'npx tslint -p tsconfig.json -e **/generated/* -c tslint.json',
-        stylelint: 'stylelint "{apps,libs}/**/*.scss" --config .stylelintrc'
-      }),
-      fix: nps.concurrent({
-        tslint:
-          'npx tslint -p tsconfig.json -e **/generated/* -c tslint.json --fix',
-        stylelint:
-          'stylelint "{apps,libs}/**/*.scss" --config .stylelintrc --fix'
-      })
-    },
-    build: {
-      default: 'nx affected:build --all --parallel',
-      affected: affected('build'),
-      ...forEachApplication(
-        nps.series(
-          'nps dev.gen-graphql',
-          nps.concurrent({
-            server: 'ng build APPLICATION --prod --maxWorkers=4 --noSourceMap',
-            client: 'ng build angular-console --configuration=APPLICATION'
-          })
-        )
-      ),
-      dev: {
-        ...forEachApplication(
-          nps.series(
-            'nps dev.gen-graphql',
-            nps.concurrent({
-              server: 'ng build APPLICATION --maxWorkers=4',
-              client: 'ng build angular-console --configuration=APPLICATION'
-            })
-          )
-        )
-      }
-    },
-    test: {
-      default: 'nx affected:test --all --parallel',
-      affected: affected('test')
-    },
-    'install-dependencies': {
-      vscode: `node ${join('tools', 'scripts', 'vscode-yarn.js')}`,
-      electron: `node ${join('tools', 'scripts', 'electron-yarn.js')}`,
-      intellij: `node ${join('tools', 'scripts', 'intellij-yarn.js')}`
     }
-  }
-};
+  };
+}


### PR DESCRIPTION
Updates package scripts and contributing docs.

**Changes**
- Commands like `prepare.vscode` and  `package.vscode` are now `vscode.prepare` and  `vscode.package` respectively.
- The dev and e2e commands are mostly intact from usage POV: `dev.up`, `e2e.prepare`, `e2e.up`, etc.