### PR TITLE
fix: Bundle visualization accounts for differential loading

### DIFF
--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -36,3 +36,21 @@ export interface NpmScripts {
   name: string;
   scripts: NpmScript[];
 }
+
+export interface StatsSummary {
+  parsed: number;
+  gzipped: number;
+}
+
+export interface Stats {
+  bundles: any[];
+  assets: any[];
+  errors?: string[];
+  warnings?: string[];
+  modulesByBundle: any;
+  summary: {
+    assets: StatsSummary;
+    modules: number;
+    dependencies: number;
+  };
+}

--- a/libs/server/src/lib/api/detailed-status-calculator.spec.ts
+++ b/libs/server/src/lib/api/detailed-status-calculator.spec.ts
@@ -17,6 +17,7 @@ describe('detailedStatusCalculator', () => {
         outputPath: undefined,
         serverHost: undefined,
         date: '',
+        stats: null,
         time: '',
         chunks: [],
         errors: [],
@@ -106,6 +107,7 @@ describe('detailedStatusCalculator', () => {
         Hash: a47cd7d40c3a7f374b97
         chunk \u001b[30m{main} main.js, main.js.map (main) 381 kB [initial] [rendered]
       `);
+      c.setStatus('successful');
 
       expect(c.detailedStatus).toEqual({
         type: StatusType.BUILD,
@@ -118,6 +120,7 @@ describe('detailedStatusCalculator', () => {
         isForProduction: false,
         outputPath: undefined,
         serverHost: undefined,
+        serverPort: undefined,
         chunks: [
           { name: 'main', file: 'main.js', size: '381 kB', type: 'initial' }
         ],
@@ -132,6 +135,7 @@ describe('detailedStatusCalculator', () => {
         Hash: a47cd7d40c3a7f374b97
         chunk {main} main.js, main.js.map (main) 381 kB [initial] [rendered]
       `);
+      c.setStatus('successful');
 
       expect(c.detailedStatus).toEqual({
         type: StatusType.BUILD,

--- a/libs/server/src/lib/utils/stats.spec.ts
+++ b/libs/server/src/lib/utils/stats.spec.ts
@@ -3,10 +3,11 @@ import { join } from 'path';
 
 describe('stats utils', () => {
   describe('generateStats', () => {
-    it('returns stats with sourcemap and stats.json', () => {
+    it('returns stats with sourcemap', () => {
       const result = generateStats(
         'dist/apps/example',
-        join(__dirname, 'fixtures')
+        join(__dirname, 'fixtures'),
+        new Date(1970, 1, 1).getTime()
       );
       expect(result.assets[0]).toEqual(
         expect.objectContaining({
@@ -43,7 +44,8 @@ describe('stats utils', () => {
     it('returns stats without sourcemap or stats.json', () => {
       const result = generateStats(
         'dist/apps/no-stats',
-        join(__dirname, 'fixtures')
+        join(__dirname, 'fixtures'),
+        new Date(1970, 1, 1).getTime()
       );
       expect(result.summary.modules).toBeGreaterThan(0);
       expect(result.summary.dependencies).toEqual(0);

--- a/libs/ui/src/lib/build-status/build-status.component.ts
+++ b/libs/ui/src/lib/build-status/build-status.component.ts
@@ -14,24 +14,7 @@ import { Subject, BehaviorSubject, combineLatest, ReplaySubject } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { MatSelectChange } from '@angular/material';
 import { GROW_SHRINK_VERT } from '../animations/grow-shink';
-
-interface Summary {
-  parsed: number;
-  gzipped: number;
-}
-
-interface Stats {
-  bundles: any[];
-  assets: any[];
-  errors: string[];
-  warnings: string[];
-  modulesByBundle: any;
-  summary: {
-    assets: Summary;
-    modules: number;
-    dependencies: number;
-  };
-}
+import { Stats } from '@angular-console/schema';
 
 export interface BuildStatus {
   buildStatus:
@@ -82,7 +65,8 @@ export class BuildStatusComponent implements OnDestroy {
         a.buildStatus === b.buildStatus &&
         a.progress === b.progress &&
         a.date === b.date &&
-        a.time === b.time
+        a.time === b.time &&
+        a.stats === b.stats
     )
   );
 
@@ -103,10 +87,10 @@ export class BuildStatusComponent implements OnDestroy {
     map(status => (status && status.stats ? status.stats.warnings : null))
   );
 
-  readonly problemsAnimationState$ = combineLatest([
+  readonly problemsAnimationState$ = combineLatest(
     this.errors$,
     this.warnings$
-  ]).pipe(
+  ).pipe(
     map(([es, ws]) => {
       return (es && es.length > 0) || (ws && ws.length > 0)
         ? 'expand'
@@ -167,7 +151,7 @@ export class BuildStatusComponent implements OnDestroy {
     })
   );
 
-  readonly buildStatus$ = combineLatest([this.status$, this.serverUrl$]).pipe(
+  readonly buildStatus$ = combineLatest(this.status$, this.serverUrl$).pipe(
     map(([status, serverUrl]) => {
       if (!status) {
         return 'Idle';
@@ -199,10 +183,10 @@ export class BuildStatusComponent implements OnDestroy {
     }
   });
 
-  readonly currentBundle$ = combineLatest([
+  readonly currentBundle$ = combineLatest(
     this.bundles$,
     this.selectedBundleFile$
-  ]).pipe(
+  ).pipe(
     map(([bundles, selected]) => {
       const c = bundles.find(x => x.file === selected);
       if (c) {
@@ -216,10 +200,10 @@ export class BuildStatusComponent implements OnDestroy {
     })
   );
 
-  readonly modulesForCurrentBundle$ = combineLatest([
+  readonly modulesForCurrentBundle$ = combineLatest(
     this.status$,
     this.selectedBundleFile$
-  ]).pipe(
+  ).pipe(
     map(([status, currentBundle]) => {
       if (!currentBundle || !status) {
         return null;


### PR DESCRIPTION
Parse the stats only at the end (when `setStatus` is called). With differential loading, webpack produces two "done" output during build (es5, then es2015) so it's not a good place to check for assets generated.

