### PR TITLE
style: Change container height to show last task item

### DIFF
--- a/libs/ui/src/lib/task-selector/task-selector.component.scss
+++ b/libs/ui/src/lib/task-selector/task-selector.component.scss
@@ -1,7 +1,7 @@
 .task-list {
   padding: 0;
   overflow: auto;
-  max-height: calc(100% - 52px);
+  max-height: calc(100% - 2 * 52px);
   min-width: calc(100vw - 52px);
 }
 


### PR DESCRIPTION
The last item is hidden below the fold and not accessible to
user.

<img width="456" alt="Screenshot 2019-06-01 at 23 16 00" src="https://user-images.githubusercontent.com/14539/58753692-c16ac580-84c3-11e9-9cff-feebc3dd8931.png">

Thanks!