### PR TITLE
fix: Use build options from project workspace configuration

### DIFF
--- a/libs/feature-run/src/lib/target/target.component.html
+++ b/libs/feature-run/src/lib/target/target.component.html
@@ -7,7 +7,7 @@
     [options]="project.architect[0].options"
     [prefix]="getPrefix(project.architect[0].name, project.name)"
     [fields]="project.architect[0].schema"
-    [init]="initSourceMapAnsStatsJson()"
+    [init]="initSourceMapAnsStatsJson(project.architect[0])"
     [runSyntax]="runSyntax(project.architect[0].name)"
     (value)="onFlagsChange($event)"
     (action)="onRun()"

--- a/libs/feature-run/src/lib/target/target.component.ts
+++ b/libs/feature-run/src/lib/target/target.component.ts
@@ -1,4 +1,4 @@
-import { Project } from '@angular-console/schema';
+import { Architect, Project } from '@angular-console/schema';
 import {
   FlagsComponent,
   TaskRunnerComponent,
@@ -176,7 +176,14 @@ export class TargetComponent implements OnInit {
     this.ngRunDisabled$.next(!e.valid);
   }
 
-  initSourceMapAnsStatsJson() {
-    return { sourceMap: true, statsJson: true };
+  initSourceMapAnsStatsJson(architect: Architect) {
+    const defaultValues = architect.configurations[0].defaultValues;
+    const sourceMap = defaultValues.find(value => value.name === 'sourceMap');
+    const statsJson = defaultValues.find(value => value.name === 'statsJson');
+
+    return {
+      sourceMap: sourceMap ? sourceMap.defaultValue : true,
+      statsJson: statsJson ? statsJson.defaultValue : true
+    };
   }
 }


### PR DESCRIPTION
fix: Use build options from project workspace configuration

The build command of a project applies default values from workspace configuration first. Fixes #605 