### PR TITLE
feat: Support providing `completion` property

### DIFF
--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -112,6 +112,7 @@ export class Serializer {
       return false;
     }
   }
+  
   private importantBuilderField(builder: string, name: string) {
     if (
       builder.startsWith('@angular-devkit/build-angular') ||

--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -13,7 +13,7 @@ export class Serializer {
         f.required ||
         this.importantSchematicField(schematic.collection, f.name),
       completion:
-        f.completion || 
+        f.completion ||
         this.completionSchematicType(schematic.collection, f.name)
     }));
     const normal = {

--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -112,7 +112,6 @@ export class Serializer {
       return false;
     }
   }
-  
   private importantBuilderField(builder: string, name: string) {
     if (
       builder.startsWith('@angular-devkit/build-angular') ||

--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -12,7 +12,9 @@ export class Serializer {
         f.positional ||
         f.required ||
         this.importantSchematicField(schematic.collection, f.name),
-      completion: f.completion || this.completionSchematicType(schematic.collection, f.name)
+      completion:
+        f.completion || 
+        this.completionSchematicType(schematic.collection, f.name)
     }));
     const normal = {
       ...schematic,

--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -12,7 +12,7 @@ export class Serializer {
         f.positional ||
         f.required ||
         this.importantSchematicField(schematic.collection, f.name),
-      completion: this.completionSchematicType(schematic.collection, f.name)
+      completion: f.completion || this.completionSchematicType(schematic.collection, f.name)
     }));
     const normal = {
       ...schematic,
@@ -33,7 +33,7 @@ export class Serializer {
         ...f,
         required: false,
         important: f.positional || this.importantBuilderField(builder, f.name),
-        completion: this.completionBuilderType(builder, f.name)
+        completion: f.completion || this.completionBuilderType(builder, f.name)
       }))
     );
   }


### PR DESCRIPTION
Add support to override completion property from schema.json

Motivation: I've created custom schematics and want to use `projects` and `localModules` completion for my custom props

Example usage:
```
{
  "$schema": "http://json-schema.org/schema",
  "id": "new-component",
  "type": "object",
  "properties": {
    "name": {
      "type": "string",
      "description": "Library name",
      "$default": {
        "$source": "argv",
        "index": 0
      }
    },
    "project": {
      "type": "string",
      "description": "Project",
      "completion": "projects",
      "$default": {
        "$source": "projectName"
      }
    },
  },
  "required": [
    "name"
  ]
}
```