### PR TITLE
fix: only bind to localhost, not all interfaces

### DIFF
--- a/apps/electron/src/app/start-server.ts
+++ b/apps/electron/src/app/start-server.ts
@@ -66,7 +66,7 @@ export async function startServer(
     );
     app.use(staticAssets(assetsPath));
 
-    return await app.listen(port, () => {
+    return await app.listen(port, 'localhost', () => {
       console.log(`Listening on port ${port}`);
     });
   } catch (e) {

--- a/apps/intellij/src/app/start-server.ts
+++ b/apps/intellij/src/app/start-server.ts
@@ -120,7 +120,7 @@ export async function startServer(
       createServerModule(exports, providers)
     );
     app.useStaticAssets(assetsPath);
-    return await app.listen(port, () => {
+    return await app.listen(port, 'localhost', () => {
       console.log(`Listening on port ${port}`);
     });
   } catch (e) {

--- a/apps/vscode/src/app/start-server.ts
+++ b/apps/vscode/src/app/start-server.ts
@@ -97,5 +97,5 @@ export async function startServer(
   });
   app.useStaticAssets(assetsPath);
 
-  return await app.listen(port, () => {});
+  return await app.listen(port, 'localhost', () => {});
 }


### PR DESCRIPTION
If you follow a trail of "this method is like that method", you end up here https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback. 

Relevant bit:

> If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.

resolves #797 