### PR TITLE
feat: default nest port changed

### DIFF
--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -134,7 +134,7 @@ function createWindow() {
     mainWindow.show();
   });
 
-  getPort({ port: 7777 }).then((port: number) => {
+  getPort({ port: 7968 }).then((port: number) => {
     try {
       startServer(port, telemetry, store, mainWindow).then(() => {
         if (fileExists(path.join(currentDirectory, 'angular.json'))) {


### PR DESCRIPTION
this is due to conflict with default nest debugging port. angular console will use a random port if it conflicts, but nest does not. 

resolves #569