### PR TITLE
feat: add generate explorer menu command

### DIFF
--- a/apps/vscode/src/app/ng-task/ng-task-commands.ts
+++ b/apps/vscode/src/app/ng-task/ng-task-commands.ts
@@ -34,19 +34,35 @@ export function registerNgTaskCommands(
       )
     );
   });
+
+  context.subscriptions.push(
+    commands.registerCommand(
+      'angularConsole.generate.explorer',
+      ({ fsPath }) => {
+        const project = n.projectForPath(fsPath);
+        selectNgCliCommandAndShowUi(
+          'generate',
+          n,
+          context.extensionPath,
+          project ? project.name : undefined
+        );
+      }
+    )
+  );
 }
 
 async function selectNgCliCommandAndShowUi(
   command: string,
   n: NgTaskProvider,
-  extensionPath: string
+  extensionPath: string,
+  projectName?: string
 ) {
-  const projectName = await selectNgCliCommand(command);
-  const workspacePath = n.getWorkspacePath();
   if (!projectName) {
-    return;
+    projectName = await selectNgCliCommand(command);
+    if (!projectName) return;
   }
 
+  const workspacePath = n.getWorkspacePath();
   if (!workspacePath) {
     window.showErrorMessage(
       'Angular Console requires a workspace be set to perform this action'

--- a/apps/vscode/src/app/ng-task/ng-task-definition.ts
+++ b/apps/vscode/src/app/ng-task/ng-task-definition.ts
@@ -19,6 +19,10 @@ export interface ProjectDef {
   };
 }
 
+export interface NamedProject extends ProjectDef {
+  name: string;
+}
+
 export interface Projects {
   [projectName: string]: ProjectDef | undefined;
 }

--- a/apps/vscode/src/app/ng-task/ng-task-provider.ts
+++ b/apps/vscode/src/app/ng-task/ng-task-provider.ts
@@ -1,11 +1,13 @@
 import { FileUtils, readJsonFile } from '@angular-console/server';
 import { ProviderResult, Task, TaskProvider, window } from 'vscode';
+import * as path from 'path';
 
 import { NgTask } from './ng-task';
 import {
   AngularJson,
   NgTaskDefinition,
   ProjectDef,
+  NamedProject,
   Projects
 } from './ng-task-definition';
 
@@ -19,8 +21,8 @@ export class NgTaskProvider implements TaskProvider {
     return this.workspacePath;
   }
 
-  setWorkspacePath(path: string) {
-    this.workspacePath = path;
+  setWorkspacePath(workspacePath: string) {
+    this.workspacePath = workspacePath;
     this.ngTasksPromise = undefined;
   }
 
@@ -93,5 +95,15 @@ export class NgTaskProvider implements TaskProvider {
 
   getProjectEntries(): [string, ProjectDef][] {
     return Object.entries(this.getProjects() || {}) as [string, ProjectDef][];
+  }
+
+  projectForPath(selectedPath: string): NamedProject | null {
+    if (!this.workspacePath) return null;
+
+    const entry = this.getProjectEntries().find(([_, def]) =>
+      selectedPath.startsWith(path.join(this.workspacePath!, def.root))
+    );
+
+    return entry ? { name: entry[0], ...entry[1] } : null;
   }
 }

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -44,6 +44,13 @@
   },
   "contributes": {
     "menus": {
+      "explorer/context": [
+        {
+          "command": "angularConsole.generate.explorer",
+          "when": "isAngularWorkspace",
+          "group": "ng"
+        }
+      ],
       "view/title": [
         {
           "command": "angularConsole.refreshAngularJsonTree",
@@ -160,6 +167,12 @@
         "category": "ng",
         "title": "xi18n (ui)",
         "command": "angularConsole.xi18n.ui",
+        "when": "isAngularWorkspace"
+      },
+      {
+        "category": "ng",
+        "title": "ng generate",
+        "command": "angularConsole.generate.explorer",
         "when": "isAngularWorkspace"
       }
     ],


### PR DESCRIPTION
 - angularConsole.generate.explorer is needed because we need a different title for the explorer menu
 - changed selectNgCliCommandAndShowUi to prompt for a project if a project is not provided