### PR TITLE
feat(vscode): autocomplete

### DIFF
--- a/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.html
@@ -12,8 +12,6 @@
       class="text-input"
       type="text"
       role="textbox"
-      [required]="field.required"
-      [attr.list]="field.enum ? field.name + '_enum' : undefined"
     />
 
     <ng-container *ngIf="(isFocused$ | async)">

--- a/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.html
@@ -1,3 +1,38 @@
-<datalist id="{{ field.name }}_enum">
-  <option *ngFor="let value of field.enum" [value]="value"></option>
-</datalist>
+<div class="description">
+  {{ field.description }}
+</div>
+
+<div class="modified-indicator"></div>
+
+<div class="control">
+  <div class="autocomplete-container">
+    <input
+      #textInput
+      [formControl]="control"
+      class="text-input"
+      type="text"
+      role="textbox"
+      [required]="field.required"
+      [attr.list]="field.enum ? field.name + '_enum' : undefined"
+    />
+
+    <ng-container *ngIf="(isFocused$ | async)">
+      <ng-container *ngIf="(visibleOptions | async) as result">
+        <div class="autocomplete-panel" role="listbox">
+          <div
+            *ngFor="let option of result; let i = index"
+            (click)="optionSelected(option)"
+            class="option"
+            role="option"
+            [class.selected]="(selectedOption$ | async) === i"
+          >
+            {{ option }}
+          </div>
+          <div *ngIf="!result.length" class="option no-result">
+            No matches for "{{ control.value }}"
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
+  </div>
+</div>

--- a/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.scss
+++ b/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.scss
@@ -1,0 +1,67 @@
+@import 'variables';
+
+angular-console-autocomplete {
+  .description {
+    margin: 0 0 0.5rem 0;
+    user-select: text;
+    white-space: normal;
+  }
+
+  .autocomplete-container {
+    position: relative;
+    width: $input-width - 2px;
+  }
+
+  input {
+    background-color: var(--vscode-settings-textInputBackground, #eee);
+    border-color: var(--vscode-settings-textInputBorder);
+    border-style: solid;
+    border-width: $input-border-width;
+    color: var(--vscode-settings-textInputForeground);
+    box-sizing: border-box;
+    font: inherit;
+    padding: 0.3rem 0.5rem;
+    width: $input-width;
+  }
+
+  .modified-indicator {
+    @include field-modified-indicator;
+  }
+
+  .autocomplete-panel {
+    background-color: var(--vscode-settings-dropdownBackground, #eee);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 30px;
+    width: 100%;
+    z-index: 10;
+  }
+
+  .no-result {
+    pointer-events: none;
+  }
+
+  .option {
+    border-color: var(--vscode-settings-dropdownBorder);
+    box-sizing: border-box;
+    padding: 0.4rem 0.6rem;
+    font-size: 14px;
+    color: var(--vscode-settings-textInputForeground);
+    cursor: pointer;
+    display: block;
+    width: 100%;
+
+    &:hover,
+    &.selected {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+  }
+}
+
+.vscode-dark .option {
+  &:hover,
+  &.selected {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+}

--- a/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.scss
+++ b/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.scss
@@ -29,11 +29,14 @@ angular-console-autocomplete {
   }
 
   .autocomplete-panel {
+    border-color: var(--vscode-settings-dropdownBorder);
     background-color: var(--vscode-settings-dropdownBackground, #eee);
     position: absolute;
     left: 0;
     right: 0;
     top: 30px;
+    max-height: 150px;
+    overflow-y: scroll;
     width: 100%;
     z-index: 10;
   }

--- a/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/vscode-ui/components/src/lib/autocomplete/autocomplete.component.ts
@@ -1,16 +1,225 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  Input,
+  SimpleChanges,
+  OnChanges,
+  ViewChild,
+  ElementRef,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
+import {
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+  FormControl
+} from '@angular/forms';
+import {
+  map,
+  tap,
+  takeUntil,
+  switchMap,
+  startWith,
+  scan,
+  debounceTime,
+  filter,
+  shareReplay
+} from 'rxjs/operators';
+import {
+  Subject,
+  BehaviorSubject,
+  Observable,
+  fromEvent,
+  merge,
+  of
+} from 'rxjs';
 import { Schema } from '@angular-console/schema';
 
-/**
- * Not built yet - using a datalist temporarily to loosely mimic functionality
- */
+enum AutocompleteNavKeys {
+  Enter = 'Enter',
+  ArrowUp = 'ArrowUp',
+  ArrowDown = 'ArrowDown'
+}
 
 @Component({
   selector: 'angular-console-autocomplete',
   templateUrl: './autocomplete.component.html',
   styleUrls: ['./autocomplete.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: AutocompleteComponent,
+      multi: true
+    }
+  ]
 })
-export class AutocompleteComponent {
+export class AutocompleteComponent
+  implements OnInit, OnDestroy, OnChanges, ControlValueAccessor {
   @Input() field: Schema;
+
+  @Input() options: string[] = [];
+  private readonly _options$ = new BehaviorSubject<string[]>(this.options);
+  visibleOptions: Observable<string[]>;
+  selectedOption$: Observable<number | null>;
+
+  @ViewChild('textInput', { static: true }) textInput: ElementRef;
+  control: FormControl;
+  isFocused$: Observable<boolean>;
+
+  private readonly _destroying$ = new Subject<void>();
+
+  constructor(private readonly _elementRef: ElementRef) {}
+
+  writeValue(value: string) {
+    if (this.control) {
+      this.control.setValue(value);
+    } else {
+      this.control = new FormControl(value);
+      this.visibleOptions = this._options$.pipe(
+        switchMap(options =>
+          this.control.valueChanges.pipe(
+            startWith(this.control.value),
+            map(formValue =>
+              options.filter(option =>
+                option.toLowerCase().includes(formValue.toLowerCase())
+              )
+            )
+          )
+        )
+      );
+    }
+  }
+
+  ngOnInit() {
+    this.isFocused$ = merge(
+      fromEvent(this._elementRef.nativeElement, 'focusin').pipe(
+        map(() => 'focus in')
+      ),
+      fromEvent(this._elementRef.nativeElement, 'focusout').pipe(
+        map(() => 'focus out')
+      )
+    ).pipe(
+      map(last => (last === 'focus in' ? true : false)),
+      startWith(false),
+      debounceTime(300),
+      shareReplay(1)
+    );
+
+    this.selectedOption$ = this.isFocused$.pipe(
+      switchMap(isFocused =>
+        isFocused
+          ? this.visibleOptions.pipe(
+              switchMap(visibleOptions =>
+                visibleOptions.length
+                  ? fromEvent<KeyboardEvent>(document, 'keyup').pipe(
+                      map((event: KeyboardEvent) => event.key),
+                      filter(key => this.isNavigationKey(key)),
+                      scan(
+                        ([index, _]: [number, string | null], key) =>
+                          [
+                            this.updatedOptionIndex(
+                              <AutocompleteNavKeys>key,
+                              index || 0,
+                              visibleOptions.length
+                            ),
+                            key
+                          ] as [number, string | null],
+                        [0, null] as [number, string | null]
+                      ),
+                      startWith([0, null] as [number, string | null]),
+
+                      tap(([index, key]) => {
+                        if (key === AutocompleteNavKeys.Enter) {
+                          this.optionSelected(visibleOptions[index]);
+                        }
+                      }),
+
+                      map(([selectedIndex]) => selectedIndex)
+                    )
+                  : of(null)
+              )
+            )
+          : of(null)
+      ),
+      shareReplay(1)
+    );
+
+    this.selectedOption$.subscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.options) {
+      this._options$.next(this.options);
+    }
+  }
+
+  /**
+   * Check if the input key is one relevant to autocomplete panel navigation
+   */
+  isNavigationKey = (key: KeyboardEvent['key']): boolean => {
+    return (
+      key === AutocompleteNavKeys.ArrowUp ||
+      key === AutocompleteNavKeys.ArrowDown ||
+      key === AutocompleteNavKeys.Enter
+    );
+  };
+
+  /**
+   * Updates the index of a selected option based on user input. If the new index
+   * is beyond the scope of the available indices, it should return an index on other
+   * side of the array (to loop around the list).
+   * @param key {AutocompleteNavKeys} KeyboardEvent.key value
+   * @param currentIndex {number} index before user input
+   * @param max {number} total number of options
+   * @returns new option index
+   */
+  updatedOptionIndex(
+    key: AutocompleteNavKeys,
+    currentIndex: number,
+    max: number
+  ): number {
+    let modifier: -1 | 0 | 1 = 0;
+
+    if (key === AutocompleteNavKeys.ArrowDown) {
+      modifier++;
+    }
+    if (key === AutocompleteNavKeys.ArrowUp) {
+      modifier--;
+    }
+
+    const temp = currentIndex + modifier;
+
+    if (temp < 0) {
+      return max - 1;
+    } else if (temp > max - 1) {
+      return 0;
+    } else {
+      return temp;
+    }
+  }
+
+  optionSelected(value: string) {
+    this.control.setValue(value);
+    this.textInput.nativeElement.blur();
+  }
+
+  registerOnChange(fn: any) {
+    this.control.valueChanges
+      .pipe(
+        tap(fn),
+        takeUntil(this._destroying$)
+      )
+      .subscribe();
+  }
+
+  registerOnTouched() {}
+
+  setDisabledState(isDisabled: boolean) {
+    isDisabled ? this.control.disable() : this.control.enable();
+  }
+
+  ngOnDestroy() {
+    this._destroying$.next();
+  }
 }

--- a/libs/vscode-ui/components/src/lib/field/field.component.html
+++ b/libs/vscode-ui/components/src/lib/field/field.component.html
@@ -6,27 +6,28 @@
   </span>
 </div>
 
-<angular-console-autocomplete
-  *ngIf="field.type === 'array'"
-  [field]="field"
-  [formControl]="control"
-  [options]="exampleOptions"
-></angular-console-autocomplete>
-
 <angular-console-checkbox
   *ngIf="field.type === 'boolean'"
   [field]="field"
   [(value)]="value"
 ></angular-console-checkbox>
 
-<angular-console-select
-  *ngIf="field.type === 'enum'"
-  [field]="field"
-  [(value)]="value"
-></angular-console-select>
-
 <angular-console-input
-  *ngIf="field.type === 'string' && (!field.enum || field.enum.length >= 10)"
+  *ngIf="field.type === 'string'"
   [field]="field"
   [(value)]="value"
 ></angular-console-input>
+
+<ng-container *ngIf="field.type === 'enum'">
+  <angular-console-autocomplete
+    *ngIf="field.enum?.length > 10"
+    [field]="field"
+    [formControl]="control"
+  ></angular-console-autocomplete>
+
+  <angular-console-select
+    *ngIf="field.enum?.length <= 10"
+    [field]="field"
+    [(value)]="value"
+  ></angular-console-select>
+</ng-container>

--- a/libs/vscode-ui/components/src/lib/field/field.component.html
+++ b/libs/vscode-ui/components/src/lib/field/field.component.html
@@ -5,22 +5,28 @@
     <ng-container *ngIf="field.required">*</ng-container>
   </span>
 </div>
-<ng-container [ngSwitch]="field.type">
-  <angular-console-checkbox
-    *ngIf="field.type === 'boolean'"
-    [field]="field"
-    [(value)]="value"
-  ></angular-console-checkbox>
 
-  <angular-console-select
-    *ngSwitchCase="'enum'"
-    [field]="field"
-    [(value)]="value"
-  ></angular-console-select>
+<angular-console-autocomplete
+  *ngIf="field.type === 'array'"
+  [field]="field"
+  [formControl]="control"
+  [options]="exampleOptions"
+></angular-console-autocomplete>
 
-  <angular-console-input
-    *ngIf="field.type === 'string' && (!field.enum || field.enum.length >= 10)"
-    [field]="field"
-    [(value)]="value"
-  ></angular-console-input>
-</ng-container>
+<angular-console-checkbox
+  *ngIf="field.type === 'boolean'"
+  [field]="field"
+  [(value)]="value"
+></angular-console-checkbox>
+
+<angular-console-select
+  *ngIf="field.type === 'enum'"
+  [field]="field"
+  [(value)]="value"
+></angular-console-select>
+
+<angular-console-input
+  *ngIf="field.type === 'string' && (!field.enum || field.enum.length >= 10)"
+  [field]="field"
+  [(value)]="value"
+></angular-console-input>

--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -36,8 +36,6 @@ export class FieldComponent implements ControlValueAccessor, OnDestroy {
 
   control = new FormControl('');
 
-  exampleOptions = ['Rhino', 'Armadillo', 'Okapi', 'Japanese spider crab'];
-
   disabled = false;
   onChange: any = () => {};
   onTouched: any = () => {};

--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -4,9 +4,15 @@ import {
   ChangeDetectorRef,
   Component,
   forwardRef,
-  Input
+  Input,
+  OnDestroy
 } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import {
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+  FormControl
+} from '@angular/forms';
+import { Subscription } from 'rxjs';
 
 /* Wrapper for select, text input, checkbox, autocomplete */
 
@@ -23,9 +29,14 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
     }
   ]
 })
-export class FieldComponent implements ControlValueAccessor {
+export class FieldComponent implements ControlValueAccessor, OnDestroy {
   @Input() field: Schema;
   _value: string;
+  valueChangeSub: Subscription;
+
+  control = new FormControl('');
+
+  exampleOptions = ['Rhino', 'Armadillo', 'Okapi', 'Japanese spider crab'];
 
   disabled = false;
   onChange: any = () => {};
@@ -57,10 +68,18 @@ export class FieldComponent implements ControlValueAccessor {
     this.disabled = isDisabled;
   }
 
-  constructor(private readonly changeDetectorRef: ChangeDetectorRef) {}
+  constructor(private readonly changeDetectorRef: ChangeDetectorRef) {
+    this.valueChangeSub = this.control.valueChanges.subscribe(value => {
+      this.value = value;
+    });
+  }
 
   camelToTitle(camelCase: string) {
     const result = camelCase.replace(/([A-Z])/g, ' $1');
     return result.charAt(0).toUpperCase() + result.slice(1);
+  }
+
+  ngOnDestroy(): void {
+    this.valueChangeSub.unsubscribe();
   }
 }

--- a/libs/vscode-ui/components/src/lib/input/input.component.html
+++ b/libs/vscode-ui/components/src/lib/input/input.component.html
@@ -1,4 +1,3 @@
-<!-- description -->
 <div class="description">
   {{ field.description }}
 </div>
@@ -16,8 +15,3 @@
     [attr.list]="field.enum ? field.name + '_enum' : undefined"
   />
 </div>
-
-<angular-console-autocomplete
-  *ngIf="field.enum"
-  [field]="field"
-></angular-console-autocomplete>

--- a/libs/vscode-ui/components/src/lib/input/input.component.html
+++ b/libs/vscode-ui/components/src/lib/input/input.component.html
@@ -12,6 +12,5 @@
     type="text"
     role="textbox"
     [required]="field.required"
-    [attr.list]="field.enum ? field.name + '_enum' : undefined"
   />
 </div>

--- a/libs/vscode-ui/components/src/lib/select/select.component.html
+++ b/libs/vscode-ui/components/src/lib/select/select.component.html
@@ -1,4 +1,3 @@
-<!-- description -->
 <div class="description">
   {{ field.description }}
 </div>

--- a/libs/vscode-ui/components/src/lib/vscode-ui-components.module.ts
+++ b/libs/vscode-ui/components/src/lib/vscode-ui-components.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 import { AutocompleteComponent } from './autocomplete/autocomplete.component';
 import { SelectComponent } from './select/select.component';
 import { InputComponent } from './input/input.component';
@@ -8,7 +9,7 @@ import { FieldComponent } from './field/field.component';
 import { FieldTreeComponent } from './field-tree/field-tree.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule],
   declarations: [
     AutocompleteComponent,
     SelectComponent,


### PR DESCRIPTION
Created autocomplete input component for VS Code

- The autocomplete component contains an input as well, which is different than most implementations. I can refactor it to attach to another component, now that the initial version is working.
- Zack suggested I use nested form controls instead of the current strategy I'm using in select, input, and checkbox, so I did that here. If this seems like a good configuration, I'll update the other inputs to use it too.
- I decided not to use the CDK overlay as it was causing some problems, but I do still have a version with it available if it should be used.
- I'm planning to work on tests next.