### PR TITLE
fix(vscode): fix opt-out event for data collection

### DIFF
--- a/apps/vscode/src/app/telemetry.ts
+++ b/apps/vscode/src/app/telemetry.ts
@@ -11,6 +11,10 @@ export function getTelemetry() {
   return telemetry;
 }
 
+const enableTelemetry = 'enableTelemetry';
+const configurationSection = VSCodeStorage.configurationSection;
+const telemetrySetting = `${configurationSection}.${enableTelemetry}`;
+
 // using shared memory here is a shortcut, this should be an api call
 export function initTelemetry(context: ExtensionContext, store: Store) {
   telemetry = environment.disableTelemetry
@@ -25,21 +29,27 @@ export function initTelemetry(context: ExtensionContext, store: Store) {
     context.globalState.update('shownTelemetryPrompt', true);
   }
 
-  const enableTelemetry = 'enableTelemetry';
-  const configurationSection = VSCodeStorage.configurationSection;
-  const telemetrySetting = `${configurationSection}.${enableTelemetry}`;
-
   disposer = workspace.onDidChangeConfiguration(e => {
     if (e.affectsConfiguration(telemetrySetting)) {
-      if (store.get(enableTelemetry, true)) {
-        telemetry.startedTracking();
-      } else {
-        telemetry.stoppedTracking();
-      }
+      updateTelemetryTracking();
     }
   });
 
+  updateTelemetryTracking();
+
   return telemetry;
+}
+
+function updateTelemetryTracking() {
+  const configuration = workspace.getConfiguration(
+    VSCodeStorage.configurationSection
+  );
+  const enabled = configuration.get('enableTelemetry');
+  if (enabled === true || typeof enabled === 'undefined') {
+    telemetry.startedTracking();
+  } else {
+    telemetry.stoppedTracking();
+  }
 }
 
 export function teardownTelemetry() {

--- a/libs/server/src/lib/telemetry/telemetry.ts
+++ b/libs/server/src/lib/telemetry/telemetry.ts
@@ -53,9 +53,12 @@ export class Telemetry implements TelemetryMessageBuilder {
   }
 
   stoppedTracking(): void {
+    // Record event before disabling data collection.
+    // Otherwise we won't get the opt-out event.
+    this.record('StoppedTracking');
+
     this.user.untracked();
     this.userStateChanged();
-    this.record('StoppedTracking');
   }
 
   userStateChanged() {


### PR DESCRIPTION
- Record "opt out" events before we stop collecting usage data.
- Reads from vscode configuration instead of our store since it doesn't appear we are updating the store anywhere.
