### PR TITLE
fix: remove duplication from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,6 @@ When you want to update the extension with a new set of changes, go back to the 
 
 Cypress, which we use to run e2e tests, records the videos of the tests ran on CI. You can access them here: [https://dashboard.cypress.io/#/projects/x2ebye/runs](https://dashboard.cypress.io/#/projects/x2ebye/runs). This is very useful for troubleshooting.
 
-## Building VSCode Plugin
-
-You can build the vscode extension and run it in development mode by opening up this repo in Visual Studio code and hitting the f5 function key. This will launch `nps prepare.dev.vscode` in the background and spawn an extension development host version of VSCode so that you can try out your code.
-
-When you want to update the extension with a new set of changes, go back to the editor you launched the extension host from and click the refresh button (its green and looks like a browser refresh icon).
-
 ## Submitting a PR
 
 Please follow the following guidelines:


### PR DESCRIPTION
The CONTRIBUTING.md file had twice the section '**Building the VSCode plugin**'. I removed the section which had less info, and left the other one which has info related to Unit and e2e tests. 